### PR TITLE
Allow Agents to change their IP addresses

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -16,6 +16,17 @@
   table now _always_ shows something.  For jobs that do not used
   the fixed key, the new tag is `randomized`.  See #536
 
+- SHIELD now tracks when it last checked each agent separately
+  from when it last "saw" the agent.  _Last Seen_ now means the
+  point in time when the agent last connected to the SHIELD core,
+  and _Last Checked_ is when the core last connected to the agent
+  for metadata retrieval.
+
+- SHIELD now allows agents to change their IP address; only the
+  agent name is unchangeable.  Previously, attempts to change an
+  agents registered IP address (without changing its name) would
+  fail.
+
 # Bug Fixes
 
 - The MotD separator no longer displays if the MotD is empty
@@ -30,4 +41,7 @@
   via the web UI and CLI.
 
 - When editing targets and stores on the webui changes are now
-  persisted when editing again without a refresh.  
+  persisted when editing again without a refresh.
+
+- The "Agents of SHIELD" admin page no longer gets stuck in a
+  loading loop whenever websocket events are seen.

--- a/db/schema.go
+++ b/db/schema.go
@@ -17,6 +17,7 @@ var Schemas = map[int]Schema{
 	6: v6Schema{},
 	7: v7Schema{},
 	8: v8Schema{},
+	9: v9Schema{},
 }
 
 type Schema interface {

--- a/db/schema_v9.go
+++ b/db/schema_v9.go
@@ -1,0 +1,27 @@
+package db
+
+type v9Schema struct{}
+
+func (s v9Schema) Deploy(db *DB) error {
+	var err error
+
+	// track last_checked_at for each agent, alongside last_seen_at,
+	// to ensure that operrators can differentiate between agent->core
+	// pings (last_seen_at) and core->agent pings (last_checked_at)
+	err = db.Exec(`ALTER TABLE agents ADD COLUMN last_checked_at INTEGER DEFAULT NULL`)
+	if err != nil {
+		return err
+	}
+
+	err = db.Exec(`UPDATE agents SET last_checked_at = last_seen_at`)
+	if err != nil {
+		return err
+	}
+
+	err = db.Exec(`UPDATE schema_info set version = 9`)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -2852,6 +2852,7 @@ for job <em>[[= _.task.job_uuid ]]</em>
                 <th>Version</th>
                 <th>Status</th>
                 <th>Last Seen</th>
+                <th>Last Checked</th>
                 <th>Visible?</th>
                 <th></th>
               </tr></thead>
@@ -2869,6 +2870,7 @@ for job <em>[[= _.task.job_uuid ]]</em>
                   [[ } ]]
                   </td>
                   <td>[[= trelative(agent.last_seen_at, 90*86400) ]]</td>
+                  <td>[[= trelative(agent.last_checked_at, 90*86400) ]]</td>
                   <td>[[ if (agent.hidden) { ]]no[[ } else { ]]yes[[ } ]]</td>
                   <td>[[ if (agent.hidden) { ]]<a href="#" rel="show">show</a>
                       [[ } else            { ]]<a href="#" rel="hide">hide</a>[[ } ]]
@@ -2876,7 +2878,7 @@ for job <em>[[= _.task.job_uuid ]]</em>
                 </tr>
                 [[ if (problems.length != 0) { ]]
                 <tr class="note fail">
-                  <td colspan="7">
+                  <td colspan="8">
                     [[ $.each(problems, function (j, problem) { ]]
                     <strong>Note:</strong><div>[[= md(problem) ]]</div>
                     [[ }); ]]

--- a/web/htdocs/js/shield.js
+++ b/web/htdocs/js/shield.js
@@ -617,6 +617,7 @@ function dispatch(page) {
       $('#main').template('access-denied', { level: 'system', need: 'engineer' });
       break;
     }
+    Scratch.track('redrawable', false);
     $('#main').template('loading');
     api({
       type: 'GET',


### PR DESCRIPTION
Fixes #526

SHIELD now tracks when it last checked each agent separately
from when it last "saw" the agent.  _Last Seen_ now means the
point in time when the agent last connected to the SHIELD core,
and _Last Checked_ is when the core last connected to the agent
for metadata retrieval.

SHIELD now allows agents to change their IP address; only the
agent name is unchangeable.  Previously, attempts to change an
agents registered IP address (without changing its name) would
fail.

The "Agents of SHIELD" admin page no longer gets stuck in a
loading loop whenever websocket events are seen.