### PR TITLE
Load Global Store Details for Admins

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -45,3 +45,9 @@
 
 - The "Agents of SHIELD" admin page no longer gets stuck in a
   loading loop whenever websocket events are seen.
+
+- Global Storage Configuration details are now properly loaded
+  when accessing a global store detail page from the admin panel.
+  Previously, the details would only load if you visited the
+  global store from the "Storage Systems" (non-admin) top-level,
+  which only works if you actually have a tenant.  See #535

--- a/web/htdocs/js/shield.js
+++ b/web/htdocs/js/shield.js
@@ -1081,6 +1081,17 @@ function dispatch(page) {
     }
     args.admin = true;
     $('#main').template('store', args);
+    $.ajax({
+      type:     'GET',
+      url:      '/v2/global/stores/'+args.uuid+'/config',
+      dataType: 'json'
+    }).then(function (config) {
+      args.config = config || []
+      $('#main').template('store', args);
+    }, function () {
+      args.config = "denied"
+      $('#main').template('store', args);
+    });
     break; /* #!/admin/stores/store */
     // }}}
   case '#!/admin/stores/new': /* {{{ */


### PR DESCRIPTION
Global Storage Configuration details are now properly loaded
when accessing a global store detail page from the admin panel.
Previously, the details would only load if you visited the
global store from the "Storage Systems" (non-admin) top-level,
which only works if you actually have a tenant.

Fixes #535.