### PR TITLE
Handle Fixed Key Rotation in Rekey Web UI

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -4,6 +4,12 @@
   and (b) change their text to indicate an ongoing operation.
   This greatly increases the usability of the web UI.  See #505
 
+- The web UI for rekeying SHIELD Core now correctly identifies
+  when the operator would like to rotate the fixed key.  Also, the
+  error messaging for an incorrect _current_ master password is
+  better now, and by default, the "rotate fixed key" checkbox on
+  the rekeying form is off.  See #546
+
 - The default password for the failsafe account has been changed
   from `shield` to `password`, for more continuity across various
   packaging formats.  See #531

--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -704,7 +704,7 @@ func (c *Core) v2API() *route.Router {
 		}
 		if err := c.vault.Unseal(c.CryptFile(), in.Master); err != nil {
 			if strings.Contains(err.Error(), "incorrect master password") {
-				r.Fail(route.Forbidden(err, "Unable to unlock the SHIELD Core: incorrect password"))
+				r.Fail(route.Forbidden(err, "Unable to unlock the SHIELD Core: incorrect master password"))
 				return
 			}
 			r.Fail(route.Oops(err, "Unable to unlock the SHIELD Core: an internal error has occurred"))
@@ -731,7 +731,11 @@ func (c *Core) v2API() *route.Router {
 
 		fixedKey, err := c.vault.Rekey(c.CryptFile(), in.Current, in.New, in.RotateFixed)
 		if err != nil {
-			r.Fail(route.Oops(err, "Unable to rekey the SHIELD Core"))
+			if strings.Contains(err.Error(), "incorrect master password") {
+				r.Fail(route.Oops(err, "Unable to rekey the SHIELD Core: incorrect (current) master password"))
+				return
+			}
+			r.Fail(route.Oops(err, "Unable to rekey the SHIELD Core: an internal error has occurred"))
 			return
 		}
 

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -3052,7 +3052,7 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
                       <div class="x3"><label for="fixed">Rekey Shield Fixed Key?</label></div>
                       <div class="x9">
                         <label for="cb-rotate" class="switch">
-                          <input id="cb-rotate" name="rotate_fixed_key" type="checkbox" checked /><span class="slider round"></span>
+                          <input id="cb-rotate" name="rotate_fixed_key" type="checkbox" /><span class="slider round"></span>
                         </label>
                         <p class="help">Rotates the key used for fixed-key backups.</p>
                       </div>

--- a/web/htdocs/js/shield.js
+++ b/web/htdocs/js/shield.js
@@ -712,7 +712,7 @@ function dispatch(page) {
           $form.error('confirm', 'mismatch');
         }
 
-        data.rotate_fixed_key = (data.rotate_fixed_key == "true");
+        data.rotate_fixed_key = !!data.rotate_fixed_key;
 
         if (!$form.isOK()) {
           return;

--- a/web/htdocs/shield.css
+++ b/web/htdocs/shield.css
@@ -2448,6 +2448,7 @@ td span.role {
 
 #dr-explain {
     font-size: 12pt;
+    padding: 2em;
 }
 
 .notice {


### PR DESCRIPTION
The web UI for rekeying SHIELD Core now correctly identifies
when the operator would like to rotate the fixed key.  Also, the
error messaging for an incorrect _current_ master password is
better now, and by default, the "rotate fixed key" checkbox on
the rekeying form is off.

Fixes #546.