### PR TITLE
Trust System CAs

### DIFF
--- a/agent/ping.go
+++ b/agent/ping.go
@@ -21,7 +21,7 @@ func (agent *Agent) Ping() {
 		return
 	}
 
-	pool := x509.NewCertPool()
+	pool, _ := x509.SystemCertPool()
 	if agent.Registration.ShieldCACert != "" {
 		if ok := pool.AppendCertsFromPEM([]byte(agent.Registration.ShieldCACert)); !ok {
 			log.Errorf("Invalid or malformed CA Certificate")

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -33,6 +33,9 @@
   agents registered IP address (without changing its name) would
   fail.
 
+- Both the SHIELD Agent and the SHIELD CLI now trust the system
+  X.509 CA Certificate Stores.  See #555 and #556
+
 # Bug Fixes
 
 - The MotD separator no longer displays if the MotD is empty

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -691,6 +691,7 @@ func main() {
 			Session:            "",
 			InsecureSkipVerify: opts.API.SkipSSLValidation,
 			CACertificate:      cacert,
+			TrustSystemCAs:     true,
 		}
 		nfo, err := c.Info()
 		bail(err)
@@ -844,6 +845,7 @@ tenants:
 		Session:            config.Current.Session,
 		InsecureSkipVerify: config.Current.InsecureSkipVerify,
 		CACertificate:      config.Current.CACertificate,
+		TrustSystemCAs:     true,
 	}
 
 	switch command {


### PR DESCRIPTION
The SHIELD Agent and the SHIELD CLI now trust System Root CAs, so if
your infrastructure uses publicly-verifiable certificates (or if you are
running your own CA, with support for it on all hosts) you should have a
better time with X.509 certificate verification.

Fixes #555 and #556.