### PR TITLE
Handle AWS 301's without Location: headers

### DIFF
--- a/plugin/s3/plugin.go
+++ b/plugin/s3/plugin.go
@@ -397,6 +397,12 @@ func (p S3Plugin) Store(endpoint plugin.ShieldEndpoint) (string, int64, error) {
 
 	upload, err := client.NewUpload(path, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "301 response missing Location header") {
+			client.UsePathBuckets = false
+			upload, err = client.NewUpload(path, nil)
+		}
+	}
+	if err != nil {
 		return "", 0, err
 	}
 
@@ -431,6 +437,12 @@ func (p S3Plugin) Retrieve(endpoint plugin.ShieldEndpoint, file string) error {
 		"    from path '%s\n"+
 		"    in bucket '%s'", file, c.Bucket)
 	reader, err := c.Get(file)
+	if err != nil {
+		if strings.Contains(err.Error(), "301 response missing Location header") {
+			c.UsePathBuckets = false
+			reader, err = c.Get(file)
+		}
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A 301 response without a Location header is an error per the HTTP RFCs.
But Amazon returns a 301 without a Location header precisely for what it
calls the PermanentRedirect error code.  This is used, during path-based
addressing to point to a bucket outside of the US regions.

This commit causes the s3 plugin to re-attempt actions when the returned
response violates this part of the HTTP speec, and re-attempt without
path-based addressing.

Fixes #568