### PR TITLE
Allow annotate-archive to take short uuids arguments

### DIFF
--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -2637,7 +2637,7 @@ tenants:
 		tenant, err := c.FindMyTenant(opts.Tenant, true)
 		bail(err)
 
-		archive, err := c.GetArchive(tenant, args[0])
+		archive, err := c.FindArchive(tenant, args[0], !opts.Exact)
 		bail(err)
 
 		archive.Notes = opts.AnnotateArchive.Notes


### PR DESCRIPTION
Switching `annotate-archive` to use the fuzzy matching of FindArchive.

This fixes #571.
