### PR TITLE
fix for bug with not being able to log in after deleting target

### DIFF
--- a/db/archives.go
+++ b/db/archives.go
@@ -158,10 +158,10 @@ func (db *DB) GetAllArchives(filter *ArchiveFilter) ([]*Archive, error) {
 		a := &Archive{}
 
 		var takenAt, expiresAt, size *int64
-		var targetName, storeName *string
+		var targetUUID, targetPlugin, targetEndpoint, targetName, storeName *string
 		if err = r.Scan(
 			&a.UUID, &a.StoreKey, &takenAt, &expiresAt, &a.Notes,
-			&a.TargetUUID, &targetName, &a.TargetPlugin, &a.TargetEndpoint,
+			&targetUUID, &targetName, &targetPlugin, &targetEndpoint,
 			&a.StoreUUID, &storeName, &a.StorePlugin, &a.StoreEndpoint, &a.StoreAgent,
 			&a.Status, &a.PurgeReason, &a.Job, &a.EncryptionType,
 			&a.Compression, &a.TenantUUID, &size); err != nil {
@@ -176,6 +176,15 @@ func (db *DB) GetAllArchives(filter *ArchiveFilter) ([]*Archive, error) {
 		}
 		if targetName != nil {
 			a.TargetName = *targetName
+		}
+		if targetUUID != nil {
+			a.TargetUUID = *targetUUID
+		}
+		if targetPlugin != nil {
+			a.TargetPlugin = *targetPlugin
+		}
+		if targetEndpoint != nil {
+			a.TargetPlugin = *targetEndpoint
 		}
 		if storeName != nil {
 			a.StoreName = *storeName


### PR DESCRIPTION
Previous when deleting a target with active archives via the cli, the web ui would log out a user and prevent them from logging in. We should now have no issue with /v2/bearings querying for archives that joins on a null job. This should fix #565. 