### PR TITLE
db locking

### DIFF
--- a/db/archives_test.go
+++ b/db/archives_test.go
@@ -106,28 +106,43 @@ var _ = Describe("Archive Management", func() {
 		ARCHIVE_STORE2 := RandomID()
 		BeforeEach(func() {
 			var err error
-			db.Exec(`INSERT INTO targets (uuid, plugin, endpoint, agent, name) VALUES("` + TARGET2_UUID + `","target_plugin2", "target_endpoint2", "127.0.0.1:5444", "target_name2")`)
-			err = db.Exec(`INSERT INTO stores (uuid, plugin, endpoint, name) VALUES("` + STORE2_UUID + `","store_plugin2", "store_endpoint2", "store_name2")`)
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO targets (uuid, plugin, endpoint, agent, name) VALUES("` + TARGET2_UUID + `","target_plugin2", "target_endpoint2", "127.0.0.1:5444", "target_name2")`)
+			db.exclusive.Unlock()
 			Expect(err).ShouldNot(HaveOccurred())
-			err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO stores (uuid, plugin, endpoint, name) VALUES("` + STORE2_UUID + `","store_plugin2", "store_endpoint2", "store_name2")`)
+			db.exclusive.Unlock()
+			Expect(err).ShouldNot(HaveOccurred())
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
 				ARCHIVE_PURGED + `","` + TARGET_UUID + `", "` + STORE_UUID +
 				`", "key", 10, 10, "purged")`)
+			db.exclusive.Unlock()
 			Expect(err).ShouldNot(HaveOccurred())
-			err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
 				ARCHIVE_INVALID + `","` + TARGET_UUID + `", "` + STORE_UUID +
 				`", "key", 10, 10, "invalid")`)
+			db.exclusive.Unlock()
 			Expect(err).ShouldNot(HaveOccurred())
-			err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
 				ARCHIVE_EXPIRED + `","` + TARGET_UUID + `", "` + STORE_UUID +
 				`", "key", 20, 20, "expired")`)
+			db.exclusive.Unlock()
 			Expect(err).ShouldNot(HaveOccurred())
-			err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
 				ARCHIVE_TARGET2 + `","` + TARGET2_UUID + `", "` + STORE_UUID +
 				`", "key", 20, 20, "valid")`)
+			db.exclusive.Unlock()
 			Expect(err).ShouldNot(HaveOccurred())
-			err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
+			db.exclusive.Lock()
+			err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
 				ARCHIVE_STORE2 + `","` + TARGET_UUID + `", "` + STORE2_UUID +
 				`", "key", 20, 20, "invalid")`)
+			db.exclusive.Unlock()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		Describe("Of Individual archives", func() {
@@ -305,24 +320,24 @@ var _ = Describe("Archive Management", func() {
 			var expectedArchiveCount int
 			BeforeEach(func() {
 				// get us a clean slate for these tests
-				err := db.Exec(`DELETE FROM archives`)
+				err := db.exec(`DELETE FROM archives`)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// insert an archive that should be expired
-				err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("`+
+				err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("`+
 					EXPIRABLE_ARCHIVE+`","`+TARGET_UUID+`", "`+STORE2_UUID+
 					`", "key", 20, ?, "valid")`, time.Now().Add(-30*time.Second).Unix())
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// insert archive expiring in a day
-				err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("`+
+				err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("`+
 					UNEXPIRED_ARCHIVE+`","`+TARGET_UUID+`", "`+STORE2_UUID+
 					`", "key", 20, ?, "valid")`, time.Now().Unix())
 
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// insert an expired but invalid archive
-				err = db.Exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
+				err = db.exec(`INSERT INTO archives (uuid, target_uuid, store_uuid, store_key, taken_at, expires_at, status) VALUES("` +
 					UNEXPIRED_ARCHIVE2 + `","` + TARGET_UUID + `", "` + STORE2_UUID +
 					`", "key", 20, 20, "invalid")`)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/db/schema.go
+++ b/db/schema.go
@@ -72,7 +72,9 @@ func currentSchema() int {
 }
 
 func (db *DB) SchemaVersion() (int, error) {
-	r, err := db.Query(`SELECT version FROM schema_info LIMIT 1`)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	r, err := db.query(`SELECT version FROM schema_info LIMIT 1`)
 	if err != nil {
 		if err.Error() == "no such table: schema_info" {
 			return 0, nil

--- a/db/schema_v1.go
+++ b/db/schema_v1.go
@@ -3,19 +3,21 @@ package db
 type v1Schema struct{}
 
 func (s v1Schema) Deploy(db *DB) error {
-	err := db.Exec(`CREATE TABLE schema_info (
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(`CREATE TABLE schema_info (
                version INTEGER
              )`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`INSERT INTO schema_info VALUES (1)`)
+	err = db.exec(`INSERT INTO schema_info VALUES (1)`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE targets (
+	err = db.exec(`CREATE TABLE targets (
 	                 uuid      UUID PRIMARY KEY,
 	                 name      TEXT,
 	                 summary   TEXT,
@@ -27,7 +29,7 @@ func (s v1Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE stores (
+	err = db.exec(`CREATE TABLE stores (
 	                 uuid      UUID PRIMARY KEY,
 	                 name      TEXT,
 	                 summary   TEXT,
@@ -38,7 +40,7 @@ func (s v1Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE schedules (
+	err = db.exec(`CREATE TABLE schedules (
 	                 uuid      UUID PRIMARY KEY,
 	                 name      TEXT,
 	                 summary   TEXT,
@@ -48,7 +50,7 @@ func (s v1Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE retention (
+	err = db.exec(`CREATE TABLE retention (
 	                 uuid     UUID PRIMARY KEY,
 	                 name     TEXT,
 	                 summary  TEXT,
@@ -58,7 +60,7 @@ func (s v1Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE jobs (
+	err = db.exec(`CREATE TABLE jobs (
 	                 uuid            UUID PRIMARY KEY,
 	                 target_uuid     UUID NOT NULL,
 	                 store_uuid      UUID NOT NULL,
@@ -73,7 +75,7 @@ func (s v1Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE archives (
+	err = db.exec(`CREATE TABLE archives (
 	                 uuid         UUID PRIMARY KEY,
 	                 target_uuid  UUID NOT NULL,
 	                 store_uuid   UUID NOT NULL,
@@ -87,7 +89,7 @@ func (s v1Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE tasks (
+	err = db.exec(`CREATE TABLE tasks (
 	                 uuid      UUID PRIMARY KEY,
 	                 owner     TEXT,
 	                 op        TEXT NOT NULL,

--- a/db/schema_v2.go
+++ b/db/schema_v2.go
@@ -3,32 +3,34 @@ package db
 type v2Schema struct{}
 
 func (s v2Schema) Deploy(db *DB) error {
-	err := db.Exec(`ALTER TABLE archives ADD COLUMN purge_reason TEXT DEFAULT ''`)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(`ALTER TABLE archives ADD COLUMN purge_reason TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE archives ADD COLUMN status TEXT DEFAULT 'valid'`)
+	err = db.exec(`ALTER TABLE archives ADD COLUMN status TEXT DEFAULT 'valid'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE archives SET status = 'valid'`)
+	err = db.exec(`UPDATE archives SET status = 'valid'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE archives ADD COLUMN size INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE archives ADD COLUMN size INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN store_uuid UUID`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN store_uuid UUID`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 2`)
+	err = db.exec(`UPDATE schema_info set version = 2`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v3.go
+++ b/db/schema_v3.go
@@ -3,47 +3,49 @@ package db
 type v3Schema struct{}
 
 func (s v3Schema) Deploy(db *DB) error {
-	err := db.Exec(`ALTER TABLE tasks ADD COLUMN target_plugin TEXT DEFAULT ''`)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(`ALTER TABLE tasks ADD COLUMN target_plugin TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN target_endpoint TEXT DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN target_endpoint TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN store_plugin TEXT DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN store_plugin TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN store_endpoint TEXT DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN store_endpoint TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN restore_key TEXT DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN restore_key TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN timeout_at INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN timeout_at INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN attempts INTEGER DEFAULT 0`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN attempts INTEGER DEFAULT 0`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN agent TEXT DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN agent TEXT DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 3`)
+	err = db.exec(`UPDATE schema_info set version = 3`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v4.go
+++ b/db/schema_v4.go
@@ -8,9 +8,11 @@ type v4Schema struct{}
 
 func (s v4Schema) Deploy(db *DB) error {
 	var err error
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
 
 	// Set up Multi-Tenancy
-	err = db.Exec(`CREATE TABLE tenants (
+	err = db.exec(`CREATE TABLE tenants (
 	                 uuid              UUID PRIMARY KEY,
 	                 name              TEXT NOT NULL DEFAULT '',
 	                 daily_increase    INTEGER DEFAULT NULL,
@@ -21,70 +23,70 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec("ALTER TABLE stores ADD agent TEXT NOT NULL DEFAULT ''")
+	err = db.exec("ALTER TABLE stores ADD agent TEXT NOT NULL DEFAULT ''")
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec("ALTER TABLE stores ADD public_config TEXT NOT NULL DEFAULT '[]'")
+	err = db.exec("ALTER TABLE stores ADD public_config TEXT NOT NULL DEFAULT '[]'")
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec("ALTER TABLE stores ADD private_config TEXT NOT NULL DEFAULT '[]'")
+	err = db.exec("ALTER TABLE stores ADD private_config TEXT NOT NULL DEFAULT '[]'")
 	if err != nil {
 		return err
 	}
 
 	tenant := RandomID()
-	err = db.Exec(`INSERT INTO tenants (uuid, name) VALUES (?, ?)`, tenant, "tenant1")
+	err = db.exec(`INSERT INTO tenants (uuid, name) VALUES (?, ?)`, tenant, "tenant1")
 	if err != nil {
 		return err
 	}
-	err = db.Exec(fmt.Sprintf("ALTER TABLE jobs ADD tenant_uuid UUID NOT NULL DEFAULT '%s'", tenant))
+	err = db.exec(fmt.Sprintf("ALTER TABLE jobs ADD tenant_uuid UUID NOT NULL DEFAULT '%s'", tenant))
 	if err != nil {
 		return err
 	}
-	err = db.Exec(fmt.Sprintf("ALTER TABLE stores ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
+	err = db.exec(fmt.Sprintf("ALTER TABLE stores ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
 	if err != nil {
 		return err
 	}
-	err = db.Exec(fmt.Sprintf("ALTER TABLE retention ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
+	err = db.exec(fmt.Sprintf("ALTER TABLE retention ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
 	if err != nil {
 		return err
 	}
-	err = db.Exec(fmt.Sprintf("ALTER TABLE archives ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
+	err = db.exec(fmt.Sprintf("ALTER TABLE archives ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
 	if err != nil {
 		return err
 	}
-	err = db.Exec(fmt.Sprintf("ALTER TABLE tasks ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
+	err = db.exec(fmt.Sprintf("ALTER TABLE tasks ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
 	if err != nil {
 		return err
 	}
-	err = db.Exec(fmt.Sprintf("ALTER TABLE targets ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
+	err = db.exec(fmt.Sprintf("ALTER TABLE targets ADD tenant_uuid UUID NOT NULL DEFAULT  '%s'", tenant))
 	if err != nil {
 		return err
 	}
 
 	// Add a next_run timestamp to the jobs
-	err = db.Exec(`ALTER TABLE jobs ADD COLUMN next_run INTEGER DEFAULT 0`)
+	err = db.exec(`ALTER TABLE jobs ADD COLUMN next_run INTEGER DEFAULT 0`)
 	if err != nil {
 		return err
 	}
 
 	// Move schedule to be a field on jobs
-	err = db.Exec(`ALTER TABLE jobs ADD COLUMN schedule TEXT`)
+	err = db.exec(`ALTER TABLE jobs ADD COLUMN schedule TEXT`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`UPDATE jobs SET schedule =
+	err = db.exec(`UPDATE jobs SET schedule =
 	                  (SELECT timespec FROM schedules
 	                   WHERE schedules.uuid = jobs.schedule_uuid)`)
 	if err != nil {
 		return err
 	}
 	// ... and remove the schedule_uuid field
-	err = db.Exec(`CREATE TABLE jobs_new (
+	err = db.exec(`CREATE TABLE jobs_new (
 	               uuid               UUID PRIMARY KEY,
 	               target_uuid        UUID NOT NULL,
 	               store_uuid         UUID NOT NULL,
@@ -101,7 +103,7 @@ func (s v4Schema) Deploy(db *DB) error {
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
+	err = db.exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
 	                                     schedule, next_run, retention_uuid,
 	                                     priority, paused, name, summary)
 	                              SELECT uuid, target_uuid, store_uuid, ?,
@@ -111,56 +113,56 @@ func (s v4Schema) Deploy(db *DB) error {
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`DROP TABLE jobs`)
+	err = db.exec(`DROP TABLE jobs`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`ALTER TABLE jobs_new RENAME TO jobs`)
-	if err != nil {
-		return err
-	}
-
-	err = db.Exec(`DROP TABLE schedules`)
+	err = db.exec(`ALTER TABLE jobs_new RENAME TO jobs`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN ok INT NOT NULL DEFAULT 1`)
+	err = db.exec(`DROP TABLE schedules`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN notes TEXT NOT NULL DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN ok INT NOT NULL DEFAULT 1`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN clear TEXT NOT NULL DEFAULT 'normal'`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN notes TEXT NOT NULL DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN relevant INT NOT NULL DEFAULT 1`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN clear TEXT NOT NULL DEFAULT 'normal'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE archives ADD COLUMN job TEXT NOT NULL DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN relevant INT NOT NULL DEFAULT 1`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE archives ADD COLUMN encryption_type TEXT NOT NULL DEFAULT ''`)
+	err = db.exec(`ALTER TABLE archives ADD COLUMN job TEXT NOT NULL DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD COLUMN fixed_key INT NOT NULL DEFAULT 0`)
+	err = db.exec(`ALTER TABLE archives ADD COLUMN encryption_type TEXT NOT NULL DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE agents (
+	err = db.exec(`ALTER TABLE tasks ADD COLUMN fixed_key INT NOT NULL DEFAULT 0`)
+	if err != nil {
+		return err
+	}
+
+	err = db.exec(`CREATE TABLE agents (
 	                 uuid          UUID PRIMARY KEY,
 	                 name          TEXT NOT NULL DEFAULT '',
 	                 address       TEXT NOT NULL DEFAULT '',
@@ -175,7 +177,7 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE users (
+	err = db.exec(`CREATE TABLE users (
 	                 uuid          UUID PRIMARY KEY,
 	                 name          TEXT NOT NULL DEFAULT '',
 	                 account       TEXT NOT NULL DEFAULT '',
@@ -192,7 +194,7 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE memberships (
+	err = db.exec(`CREATE TABLE memberships (
 	                 user_uuid     UUID NOT NULL,
 	                 tenant_uuid   UUID NOT NULL,
 	                 role          VARCHAR(100) NOT NULL,
@@ -202,7 +204,7 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`CREATE TABLE sessions (
+	err = db.exec(`CREATE TABLE sessions (
 	                 uuid          UUID PRIMARY KEY,
 	                 user_uuid     UUID NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
 	                 created_at    INTEGER NOT NULL,
@@ -217,55 +219,55 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN daily_increase INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE stores ADD COLUMN daily_increase INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN storage_used INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE stores ADD COLUMN storage_used INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN archive_count INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE stores ADD COLUMN archive_count INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN threshold INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE stores ADD COLUMN threshold INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN healthy BOOLEAN DEFAULT FALSE`)
+	err = db.exec(`ALTER TABLE stores ADD COLUMN healthy BOOLEAN DEFAULT FALSE`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN last_test_task_uuid BOOLEAN DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE stores ADD COLUMN last_test_task_uuid BOOLEAN DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
 	/* provide summaries */
-	err = db.Exec(`UPDATE stores SET summary = '' WHERE summary IS NULL`)
+	err = db.exec(`UPDATE stores SET summary = '' WHERE summary IS NULL`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`UPDATE targets SET summary = '' WHERE summary IS NULL`)
+	err = db.exec(`UPDATE targets SET summary = '' WHERE summary IS NULL`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`UPDATE retention SET summary = '' WHERE summary IS NULL`)
+	err = db.exec(`UPDATE retention SET summary = '' WHERE summary IS NULL`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`UPDATE jobs SET summary = '' WHERE summary IS NULL`)
+	err = db.exec(`UPDATE jobs SET summary = '' WHERE summary IS NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 4`)
+	err = db.exec(`UPDATE schema_info set version = 4`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v5.go
+++ b/db/schema_v5.go
@@ -4,38 +4,40 @@ type v5Schema struct{}
 
 func (s v5Schema) Deploy(db *DB) error {
 	var err error
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
 
-	err = db.Exec(`ALTER TABLE targets ADD compression TEXT NOT NULL DEFAULT 'none'`)
+	err = db.exec(`ALTER TABLE targets ADD compression TEXT NOT NULL DEFAULT 'none'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE targets SET compression = 'bzip2'`)
+	err = db.exec(`UPDATE targets SET compression = 'bzip2'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE archives ADD compression TEXT NOT NULL DEFAULT 'none'`)
+	err = db.exec(`ALTER TABLE archives ADD compression TEXT NOT NULL DEFAULT 'none'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE archives SET compression = 'bzip2'`)
+	err = db.exec(`UPDATE archives SET compression = 'bzip2'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE tasks ADD compression TEXT NOT NULL DEFAULT ''`)
+	err = db.exec(`ALTER TABLE tasks ADD compression TEXT NOT NULL DEFAULT ''`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE tasks SET compression = 'bzip2' WHERE op = 'backup'`)
+	err = db.exec(`UPDATE tasks SET compression = 'bzip2' WHERE op = 'backup'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 5`)
+	err = db.exec(`UPDATE schema_info set version = 5`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v6.go
+++ b/db/schema_v6.go
@@ -9,8 +9,11 @@ type v6Schema struct{}
 func (s v6Schema) Deploy(db *DB) error {
 	var err error
 
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+
 	// set the tenant_uuid column to NOT NULL
-	err = db.Exec(`CREATE TABLE jobs_new (
+	err = db.exec(`CREATE TABLE jobs_new (
 	               uuid               UUID PRIMARY KEY,
 	               target_uuid        UUID NOT NULL,
 	               store_uuid         UUID NOT NULL,
@@ -28,7 +31,7 @@ func (s v6Schema) Deploy(db *DB) error {
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
+	err = db.exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
 	                                     schedule, next_run, keep_days,
 	                                     priority, paused, name, summary)
 	                              SELECT j.uuid, j.target_uuid, j.store_uuid, j.tenant_uuid,
@@ -39,32 +42,35 @@ func (s v6Schema) Deploy(db *DB) error {
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`DROP TABLE jobs`)
+	err = db.exec(`DROP TABLE jobs`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`ALTER TABLE jobs_new RENAME TO jobs`)
+	err = db.exec(`ALTER TABLE jobs_new RENAME TO jobs`)
 	if err != nil {
 		return err
 	}
-	err = db.Exec(`DROP TABLE retention`)
+	err = db.exec(`DROP TABLE retention`)
 	if err != nil {
 		return err
 	}
 
 	/* fix keep_n on all jobs */
-	jobs, err := db.GetAllJobs(nil)
+	jobs, err := db.doGetAllJobs(nil)
 	if err != nil {
 		return err
 	}
 	for _, job := range jobs {
 		if sched, err := timespec.Parse(job.Schedule); err != nil {
 			job.KeepN = sched.KeepN(job.KeepDays)
-			db.UpdateJob(job)
+			err = db.doUpdateJob(job)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 6`)
+	err = db.exec(`UPDATE schema_info set version = 6`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v7.go
+++ b/db/schema_v7.go
@@ -4,14 +4,16 @@ type v7Schema struct{}
 
 func (s v7Schema) Deploy(db *DB) error {
 	var err error
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
 
 	// rename tenant1 -> 'Default Tenant'
-	err = db.Exec(`UPDATE tenants SET name = 'Default Tenant' WHERE name = 'tenant1'`)
+	err = db.exec(`UPDATE tenants SET name = 'Default Tenant' WHERE name = 'tenant1'`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 7`)
+	err = db.exec(`UPDATE schema_info set version = 7`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v8.go
+++ b/db/schema_v8.go
@@ -4,9 +4,11 @@ type v8Schema struct{}
 
 func (s v8Schema) Deploy(db *DB) error {
 	var err error
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
 
 	// track what fixups were done, and when
-	err = db.Exec(`CREATE TABLE fixups (
+	err = db.exec(`CREATE TABLE fixups (
 	                 id         VARCHAR(100) PRIMARY KEY,
 	                 name       TEXT,
 	                 summary    TEXT,
@@ -17,7 +19,7 @@ func (s v8Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 8`)
+	err = db.exec(`UPDATE schema_info set version = 8`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v9.go
+++ b/db/schema_v9.go
@@ -4,21 +4,23 @@ type v9Schema struct{}
 
 func (s v9Schema) Deploy(db *DB) error {
 	var err error
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
 
 	// track last_checked_at for each agent, alongside last_seen_at,
 	// to ensure that operrators can differentiate between agent->core
 	// pings (last_seen_at) and core->agent pings (last_checked_at)
-	err = db.Exec(`ALTER TABLE agents ADD COLUMN last_checked_at INTEGER DEFAULT NULL`)
+	err = db.exec(`ALTER TABLE agents ADD COLUMN last_checked_at INTEGER DEFAULT NULL`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE agents SET last_checked_at = last_seen_at`)
+	err = db.exec(`UPDATE agents SET last_checked_at = last_seen_at`)
 	if err != nil {
 		return err
 	}
 
-	err = db.Exec(`UPDATE schema_info set version = 9`)
+	err = db.exec(`UPDATE schema_info set version = 9`)
 	if err != nil {
 		return err
 	}

--- a/db/stores.go
+++ b/db/stores.go
@@ -136,7 +136,9 @@ func (db *DB) GetAllStores(filter *StoreFilter) ([]*Store, error) {
 
 	l := []*Store{}
 	query, args := filter.Query()
-	r, err := db.Query(query, args...)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	r, err := db.query(query, args...)
 	if err != nil {
 		return l, err
 	}
@@ -189,7 +191,14 @@ func (db *DB) GetAllStores(filter *StoreFilter) ([]*Store, error) {
 }
 
 func (db *DB) GetStore(id string) (*Store, error) {
-	r, err := db.Query(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.doGetStore(id)
+}
+
+//The caller must Lock the Mutex
+func (db *DB) doGetStore(id string) (*Store, error) {
+	r, err := db.query(`
 	       SELECT s.uuid, s.name, s.summary, s.agent,
 	              s.plugin, s.endpoint, s.tenant_uuid,
 	              s.daily_increase,
@@ -256,7 +265,9 @@ func (db *DB) CreateStore(store *Store) (*Store, error) {
 	}
 
 	store.UUID = RandomID()
-	err = db.Exec(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err = db.exec(`
 	   INSERT INTO stores (uuid, tenant_uuid, name, summary, agent,
 	                       plugin, endpoint,
 	                       threshold, healthy, last_test_task_uuid)
@@ -284,7 +295,9 @@ func (db *DB) UpdateStore(store *Store) error {
 		return fmt.Errorf("unable to marshal storage endpoint configs: %s", err)
 	}
 
-	err = db.Exec(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err = db.exec(`
 	   UPDATE stores
 	      SET name                    = ?,
 	          summary                 = ?,
@@ -307,7 +320,7 @@ func (db *DB) UpdateStore(store *Store) error {
 		return err
 	}
 
-	update, err := db.GetStore(store.UUID)
+	update, err := db.doGetStore(store.UUID)
 	if err != nil {
 		return err
 	}
@@ -320,7 +333,9 @@ func (db *DB) UpdateStore(store *Store) error {
 }
 
 func (db *DB) DeleteStore(id string) (bool, error) {
-	store, err := db.GetStore(id)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	store, err := db.doGetStore(id)
 	if err != nil {
 		return false, err
 	}
@@ -330,30 +345,16 @@ func (db *DB) DeleteStore(id string) (bool, error) {
 		return true, nil
 	}
 
-	r, err := db.Query(`SELECT COUNT(uuid) FROM jobs WHERE jobs.store_uuid = ?`, store.UUID)
+	numJobs, err := db.count(`SELECT * FROM jobs WHERE jobs.store_uuid = ?`, store.UUID)
 	if err != nil {
 		return false, err
 	}
-	defer r.Close()
 
-	if !r.Next() {
-		/* already deleted (temporal anomaly detected) */
-		return true, nil
-	}
-
-	var numJobs int
-	if err = r.Scan(&numJobs); err != nil {
-		return false, err
-	}
-	if numJobs < 0 {
-		return false, fmt.Errorf("Store %s is in used by %d (negative) Jobs", id, numJobs)
-	}
 	if numJobs > 0 {
 		return false, nil
 	}
-	r.Close()
 
-	err = db.Exec(`DELETE FROM stores WHERE uuid = ?`, store.UUID)
+	err = db.exec(`DELETE FROM stores WHERE uuid = ?`, store.UUID)
 	if err != nil {
 		return false, err
 	}
@@ -371,7 +372,9 @@ func (store Store) ConfigJSON() (string, error) {
 }
 
 func (db *DB) CleanStores() error {
-	return db.Exec(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.exec(`
 	   DELETE FROM stores
 	         WHERE uuid IN (SELECT uuid
 	                          FROM stores s WHERE tenant_uuid = ''

--- a/db/targets.go
+++ b/db/targets.go
@@ -121,19 +121,12 @@ func (db *DB) CountTargets(filter *TargetFilter) (int, error) {
 		filter = &TargetFilter{}
 	}
 
-	var i int
 	query, args := filter.Query()
-	r, err := db.Query(query, args...)
-	if err != nil {
-		return i, err
-	}
-	defer r.Close()
-
-	for r.Next() {
-		i++
-	}
-
-	return i, nil
+	db.exclusive.Lock()
+	uintRet, err := db.count(query, args...)
+	db.exclusive.Unlock()
+	ret := int(uintRet)
+	return ret, err
 }
 
 func (db *DB) GetAllTargets(filter *TargetFilter) ([]*Target, error) {
@@ -143,7 +136,9 @@ func (db *DB) GetAllTargets(filter *TargetFilter) ([]*Target, error) {
 
 	l := []*Target{}
 	query, args := filter.Query()
-	r, err := db.Query(query, args...)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	r, err := db.query(query, args...)
 	if err != nil {
 		return l, err
 	}
@@ -172,7 +167,14 @@ func (db *DB) GetAllTargets(filter *TargetFilter) ([]*Target, error) {
 }
 
 func (db *DB) GetTarget(id string) (*Target, error) {
-	r, err := db.Query(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.doGetTarget(id)
+}
+
+//The caller must Lock the db Mutex
+func (db *DB) doGetTarget(id string) (*Target, error) {
+	r, err := db.query(`
 	    SELECT uuid, tenant_uuid, name, summary, plugin,
 	           endpoint, agent, compression
 
@@ -212,7 +214,9 @@ func (db *DB) CreateTarget(target *Target) (*Target, error) {
 	}
 
 	target.UUID = RandomID()
-	err = db.Exec(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err = db.exec(`
 	    INSERT INTO targets (uuid, tenant_uuid, name, summary, plugin,
 	                         endpoint, agent, compression)
 	                 VALUES (?, ?, ?, ?, ?,
@@ -233,7 +237,9 @@ func (db *DB) UpdateTarget(target *Target) error {
 		return err
 	}
 
-	err = db.Exec(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err = db.exec(`
 	  UPDATE targets
 	     SET name        = ?,
 	         summary     = ?,
@@ -248,7 +254,7 @@ func (db *DB) UpdateTarget(target *Target) error {
 		return err
 	}
 
-	update, err := db.GetTarget(target.UUID)
+	update, err := db.doGetTarget(target.UUID)
 	if err != nil {
 		return err
 	}
@@ -261,7 +267,9 @@ func (db *DB) UpdateTarget(target *Target) error {
 }
 
 func (db *DB) DeleteTarget(id string) (bool, error) {
-	target, err := db.GetTarget(id)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	target, err := db.doGetTarget(id)
 	if err != nil {
 		return false, err
 	}
@@ -271,30 +279,16 @@ func (db *DB) DeleteTarget(id string) (bool, error) {
 		return true, nil
 	}
 
-	r, err := db.Query(`SELECT COUNT(uuid) FROM jobs WHERE jobs.target_uuid = ?`, target.UUID)
+	numJobs, err := db.count(`SELECT * FROM jobs WHERE jobs.target_uuid = ?`, target.UUID)
 	if err != nil {
 		return false, err
 	}
-	defer r.Close()
 
-	if !r.Next() {
-		/* already deleted (temporal anomaly detected) */
-		return true, nil
-	}
-
-	var numJobs int
-	if err = r.Scan(&numJobs); err != nil {
-		return false, err
-	}
-	if numJobs < 0 {
-		return false, fmt.Errorf("Target %s is in used by %d (negative) Jobs", id, numJobs)
-	}
 	if numJobs > 0 {
 		return false, nil
 	}
-	r.Close()
 
-	err = db.Exec(`DELETE FROM targets WHERE uuid = ?`, id)
+	err = db.exec(`DELETE FROM targets WHERE uuid = ?`, id)
 	if err != nil {
 		return false, err
 	}
@@ -304,7 +298,9 @@ func (db *DB) DeleteTarget(id string) (bool, error) {
 }
 
 func (db *DB) CleanTargets() error {
-	return db.Exec(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.exec(`
 	   DELETE FROM targets
 	         WHERE uuid in (SELECT uuid
 	                          FROM targets t

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -190,13 +190,20 @@ func (f *TaskFilter) Query() (string, []interface{}) {
 }
 
 func (db *DB) GetAllTasks(filter *TaskFilter) ([]*Task, error) {
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.doGetAllTasks(filter)
+}
+
+//The caller must Lock the db Mutex
+func (db *DB) doGetAllTasks(filter *TaskFilter) ([]*Task, error) {
 	if filter == nil {
 		filter = &TaskFilter{}
 	}
 
 	l := []*Task{}
 	query, args := filter.Query()
-	r, err := db.Query(query, args...)
+	r, err := db.query(query, args...)
 	if err != nil {
 		return l, err
 	}
@@ -256,7 +263,14 @@ func (db *DB) GetAllTasks(filter *TaskFilter) ([]*Task, error) {
 }
 
 func (db *DB) GetTask(id string) (*Task, error) {
-	r, err := db.GetAllTasks(&TaskFilter{UUID: id, ExactMatch: true})
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.doGetTask(id)
+}
+
+//The caller must Lock the db Mutex
+func (db *DB) doGetTask(id string) (*Task, error) {
+	r, err := db.doGetAllTasks(&TaskFilter{UUID: id, ExactMatch: true})
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +282,9 @@ func (db *DB) GetTask(id string) (*Task, error) {
 
 func (db *DB) CreateInternalTask(owner, op, tenant string) (*Task, error) {
 	id := RandomID()
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`INSERT INTO tasks
 		    (uuid, owner, op, status, tenant_uuid, log, requested_at)
 		  VALUES
@@ -279,7 +295,7 @@ func (db *DB) CreateInternalTask(owner, op, tenant string) (*Task, error) {
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +311,9 @@ func (db *DB) CreateBackupTask(owner string, job *Job) (*Task, error) {
 	id := RandomID()
 	archive := RandomID()
 
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`INSERT INTO tasks
 		    (uuid, owner, op, job_uuid, status, log, requested_at,
 		     archive_uuid, store_uuid, store_plugin, store_endpoint,
@@ -316,7 +334,7 @@ func (db *DB) CreateBackupTask(owner string, job *Job) (*Task, error) {
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +349,9 @@ func (db *DB) CreateBackupTask(owner string, job *Job) (*Task, error) {
 func (db *DB) SkipBackupTask(owner string, job *Job, msg string) (*Task, error) {
 	id := RandomID()
 	now := time.Now().Unix()
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`INSERT INTO tasks
 		    (uuid, owner, op, job_uuid, status, log,
 		     requested_at, started_at, stopped_at, ok,
@@ -355,7 +375,7 @@ func (db *DB) SkipBackupTask(owner string, job *Job, msg string) (*Task, error) 
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +394,9 @@ func (db *DB) CreateRestoreTask(owner string, archive *Archive, target *Target) 
 	}
 
 	id := RandomID()
-	err = db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err = db.exec(
 		`INSERT INTO tasks
 		    (uuid, owner, op, archive_uuid, status, log, requested_at,
 		     store_uuid, store_plugin, store_endpoint,
@@ -395,7 +417,7 @@ func (db *DB) CreateRestoreTask(owner string, archive *Archive, target *Target) 
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +431,9 @@ func (db *DB) CreateRestoreTask(owner string, archive *Archive, target *Target) 
 
 func (db *DB) CreatePurgeTask(owner string, archive *Archive) (*Task, error) {
 	id := RandomID()
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`INSERT INTO tasks
 		    (uuid, owner, op, archive_uuid, status, log, requested_at,
 		     store_uuid, store_plugin, store_endpoint,
@@ -430,7 +454,7 @@ func (db *DB) CreatePurgeTask(owner string, archive *Archive) (*Task, error) {
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +472,9 @@ func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
 		return nil, err
 	}
 	id := RandomID()
-	err = db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err = db.exec(
 		`INSERT INTO tasks
 			(uuid, op,
 			 store_uuid, store_plugin, store_endpoint,
@@ -468,7 +494,7 @@ func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
 		return nil, err
 	}
 
-	err = db.Exec(
+	err = db.exec(
 		`UPDATE stores
 		 SET last_test_task_uuid = ?
 		 WHERE uuid=?`,
@@ -478,7 +504,7 @@ func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +521,9 @@ func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
 }
 
 func (db *DB) CreateAgentStatusTask(owner string, agent *Agent) (*Task, error) {
-	r, err := db.Query(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	r, err := db.query(`
 	   SELECT uuid
 
 	     FROM tasks
@@ -513,11 +541,11 @@ func (db *DB) CreateAgentStatusTask(owner string, agent *Agent) (*Task, error) {
 		if err = r.Scan(&id); err != nil {
 			return nil, err
 		}
-		return db.GetTask(id)
+		return db.doGetTask(id)
 	}
 
 	id := RandomID()
-	err = db.Exec(`
+	err = db.exec(`
 	   INSERT INTO tasks (uuid, op, status, log, requested_at,
 	                      tenant_uuid, agent, attempts, owner, tenant_uuid)
 	
@@ -531,7 +559,7 @@ func (db *DB) CreateAgentStatusTask(owner string, agent *Agent) (*Task, error) {
 		return nil, err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +576,10 @@ func (db *DB) IsTaskRunnable(task *Task) (bool, error) {
 	if task.TargetUUID == "" {
 		return true, nil
 	}
-	r, err := db.Query(`
+
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	r, err := db.query(`
 		SELECT uuid FROM tasks
 		  WHERE target_uuid = ? AND status = ? LIMIT 1`, task.TargetUUID, RunningStatus)
 	if err != nil {
@@ -562,8 +593,9 @@ func (db *DB) IsTaskRunnable(task *Task) (bool, error) {
 	return false, nil
 }
 
+//The caller must Lock the db mutex
 func (db *DB) taskQueue(id string) string {
-	r, err := db.Query(`SELECT tenant_uuid FROM tasks WHERE uuid = ?`, id)
+	r, err := db.query(`SELECT tenant_uuid FROM tasks WHERE uuid = ?`, id)
 	if err != nil {
 		return ""
 	}
@@ -581,7 +613,9 @@ func (db *DB) taskQueue(id string) string {
 }
 
 func (db *DB) StartTask(id string, at time.Time) error {
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`UPDATE tasks SET status = ?, started_at = ? WHERE uuid = ?`,
 		RunningStatus, effectively(at), id,
 	)
@@ -589,7 +623,7 @@ func (db *DB) StartTask(id string, at time.Time) error {
 		return err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return err
 	}
@@ -602,14 +636,16 @@ func (db *DB) StartTask(id string, at time.Time) error {
 }
 
 func (db *DB) ScheduledTask(id string) error {
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`UPDATE tasks SET status = ? WHERE uuid = ?`,
 		ScheduledStatus, id)
 	if err != nil {
 		return err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return err
 	}
@@ -622,14 +658,16 @@ func (db *DB) ScheduledTask(id string) error {
 }
 
 func (db *DB) updateTaskStatus(id, status string, at int64, ok int) error {
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`UPDATE tasks SET status = ?, stopped_at = ?, ok = ? WHERE uuid = ?`,
 		status, at, ok, id)
 	if err != nil {
 		return err
 	}
 
-	task, err := db.GetTask(id)
+	task, err := db.doGetTask(id)
 	if err != nil {
 		return err
 	}
@@ -648,19 +686,24 @@ func (db *DB) updateTaskStatus(id, status string, at int64, ok int) error {
 }
 
 func (db *DB) CancelTask(id string, at time.Time) error {
+	//updateTaskStatus grabs the lock
 	return db.updateTaskStatus(id, CanceledStatus, effectively(at), 1)
 }
 
 func (db *DB) FailTask(id string, at time.Time) error {
+	//updateTaskStatus grabs the lock
 	return db.updateTaskStatus(id, FailedStatus, effectively(at), 0)
 }
 
 func (db *DB) CompleteTask(id string, at time.Time) error {
+	//updateTaskStatus grabs the lock
 	return db.updateTaskStatus(id, DoneStatus, effectively(at), 1)
 }
 
 func (db *DB) UpdateTaskLog(id string, more string) error {
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`UPDATE tasks SET log = log || ? WHERE uuid = ?`,
 		more, id,
 	)
@@ -678,7 +721,9 @@ func (db *DB) CreateTaskArchive(id, archive_id, key string, at time.Time, encryp
 	}
 
 	// determine how long we need to keep this specific archive for
-	r, err := db.Query(`
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	r, err := db.query(`
 	       SELECT j.keep_days
 	         FROM jobs j
 	   INNER JOIN tasks t ON j.uuid = t.job_uuid
@@ -700,7 +745,7 @@ func (db *DB) CreateTaskArchive(id, archive_id, key string, at time.Time, encryp
 	r.Close()
 
 	// insert an archive with all proper references, expiration, etc.
-	err = db.Exec(`
+	err = db.exec(`
 	  INSERT INTO archives
 	    (uuid, target_uuid, store_uuid, store_key, taken_at,
 	     expires_at, notes, status, purge_reason, job,
@@ -724,7 +769,7 @@ func (db *DB) CreateTaskArchive(id, archive_id, key string, at time.Time, encryp
 	}
 
 	// and finally, associate task -> archive
-	return archive_id, db.Exec(
+	return archive_id, db.exec(
 		`UPDATE tasks SET archive_uuid = ? WHERE uuid = ?`,
 		archive_id, id,
 	)
@@ -754,13 +799,17 @@ func (db *DB) AnnotateTargetTask(target, id string, t *TaskAnnotation) error {
 	}
 
 	args = append(args, target, id)
-	return db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.exec(
 		`UPDATE tasks SET `+strings.Join(updates, ", ")+
 			`WHERE target_uuid = ? AND uuid = ?`, args...)
 }
 
 func (db *DB) MarkTasksIrrelevant() error {
-	err := db.Exec(
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	err := db.exec(
 		`UPDATE tasks SET relevant = 0
 		  WHERE relevant = 1
 		    AND clear = 'immediate'`)
@@ -769,7 +818,7 @@ func (db *DB) MarkTasksIrrelevant() error {
 		return err
 	}
 
-	err = db.Exec(
+	err = db.exec(
 		`UPDATE tasks SET relevant = 0
 		  WHERE relevant = 1 AND clear = 'normal'
 		    AND uuid IN (
@@ -781,7 +830,7 @@ func (db *DB) MarkTasksIrrelevant() error {
 		return err
 	}
 
-	err = db.Exec(
+	err = db.exec(
 		`UPDATE tasks SET relevant = 1
 		  WHERE relevant = 0 AND clear = 'manual'`)
 	if err != nil {
@@ -808,5 +857,7 @@ func (db *DB) RedactAllTaskLogs(tasks []*Task) {
 //UnscheduleAllTasks takes all tasks which are in the scheduled state and puts
 //them back in a pending state.
 func (db *DB) UnscheduleAllTasks() error {
-	return db.Exec(`UPDATE tasks SET status = 'pending' WHERE status = 'scheduled'`)
+	db.exclusive.Lock()
+	defer db.exclusive.Unlock()
+	return db.exec(`UPDATE tasks SET status = 'pending' WHERE status = 'scheduled'`)
 }

--- a/plugin/mongo/plugin.go
+++ b/plugin/mongo/plugin.go
@@ -218,7 +218,7 @@ func (p MongoPlugin) Purge(endpoint plugin.ShieldEndpoint, file string) error {
 }
 
 func connectionString(info *MongoConnectionInfo, backup bool) string {
-	opts := fmt.Sprintf("--archive --host %s", info.Host);
+	opts := fmt.Sprintf("--archive --host %s", info.Host)
 
 	if info.Options != "" {
 		opts += fmt.Sprintf(" %s ", info.Options)


### PR DESCRIPTION
We had race conditions in the db layer! no longer! The lock grabbing is moved up an abstraction layer. It is very ugly now - this is an increase in both functionality and ugliness in equal measure.

This fixes:
* Issues where row iterations would hold the read lock on the database without holding the SHIELD db layer Mutex.
* Issues where sequences of queries that should be transactional were effectively not being the lock was being taken, released, and then taken again.

As I was going through the db tests, there are also a few lines where errors were not being checked. Now they're being checked. Hooray.