### PR TITLE
Remove extra bottom margin from data system card

### DIFF
--- a/web/htdocs/shield.css
+++ b/web/htdocs/shield.css
@@ -876,7 +876,7 @@ footer p {
 .summary {
   padding: 1%;
   width: 42%;
-  margin: 2% 0 10% 2%;
+  margin: 2% 0 0 2%;
   float: left;
 }
 .store .summary {


### PR DESCRIPTION
Make bottom margin of data system card in web UI less, so that I can no longer fit other imaginary cards inside of the space between cards. Now I can see more cards per screen (CPS). CPS++