### PR TITLE
WebSocket Improvements

### DIFF
--- a/core/bus/bus.go
+++ b/core/bus/bus.go
@@ -27,6 +27,12 @@ type Event struct {
 type Bus struct {
 	lock  sync.Mutex
 	slots []slot
+
+	lifetime, current struct {
+		connections int64
+	}
+	events   map[string]int64
+	messages map[string]int64
 }
 
 type slot struct {
@@ -35,9 +41,12 @@ type slot struct {
 }
 
 func New(n int) *Bus {
-	return &Bus{
+	b := Bus{
 		slots: make([]slot, n),
 	}
+	b.events = make(map[string]int64)
+	b.messages = make(map[string]int64)
+	return &b
 }
 
 func (b *Bus) Register(queues []string) (chan Event, int, error) {
@@ -46,6 +55,8 @@ func (b *Bus) Register(queues []string) (chan Event, int, error) {
 
 	for i := range b.slots {
 		if b.slots[i].ch == nil {
+			b.lifetime.connections += 1
+			b.current.connections += 1
 			b.slots[i].ch = make(chan Event, 0)
 			b.slots[i].acl = make(map[string]bool)
 			for _, q := range queues {
@@ -67,12 +78,12 @@ func (b *Bus) Unregister(idx int) error {
 		return fmt.Errorf("could not unregister channel #%d: index out of range", idx)
 	}
 
+	b.current.connections -= 1
 	ch := b.slots[idx].ch
 	b.slots[idx].ch = nil
 	b.slots[idx].acl = nil
 
-	for range ch {
-	}
+	close(ch)
 	return nil
 }
 
@@ -95,6 +106,14 @@ func (b *Bus) SendEvent(queues []string, ev Event) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
+	if _, ok := b.events[ev.Event]; !ok {
+		b.events[ev.Event] = 0
+	}
+	if _, ok := b.messages[ev.Event]; !ok {
+		b.messages[ev.Event] = 0
+	}
+
+	b.events[ev.Event] += 1
 	for _, s := range b.slots {
 		if s.ch == nil {
 			continue
@@ -105,6 +124,7 @@ func (b *Bus) SendEvent(queues []string, ev Event) {
 				if q == "*" {
 					ev.Queue = q
 					s.ch <- ev
+					b.messages[ev.Event] += 1
 					return
 				}
 			}
@@ -112,6 +132,7 @@ func (b *Bus) SendEvent(queues []string, ev Event) {
 				if _, ok := s.acl[q]; ok {
 					ev.Queue = q
 					s.ch <- ev
+					b.messages[ev.Event] += 1
 					return
 				}
 			}

--- a/core/bus/debug.go
+++ b/core/bus/debug.go
@@ -1,16 +1,41 @@
 package bus
 
-func (b *Bus) DumpState() [][]string {
+type Metrics struct {
+	Connections struct {
+		Lifetime int64 `json:"lifetime"`
+		Current  int64 `json:"current"`
+	} `json:"connections"`
+	Events   map[string]int64 `json:"events"`
+	Messages map[string]int64 `json:"messages"`
+
+	Slots [][]string `json:"clients"`
+}
+
+func (b *Bus) DumpState() Metrics {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	slots := make([][]string, len(b.slots))
-	for i := range slots {
-		slots[i] = make([]string, 0)
+	var m Metrics
+	m.Connections.Lifetime = b.lifetime.connections
+	m.Connections.Current = b.current.connections
+
+	m.Events = make(map[string]int64)
+	for t, n := range b.events {
+		m.Events[t] = n
+	}
+
+	m.Messages = make(map[string]int64)
+	for t, n := range b.messages {
+		m.Messages[t] = n
+	}
+
+	m.Slots = make([][]string, len(b.slots))
+	for i := range b.slots {
+		m.Slots[i] = make([]string, 0)
 		for q := range b.slots[i].acl {
-			slots[i] = append(slots[i], q)
+			m.Slots[i] = append(m.Slots[i], q)
 		}
 	}
 
-	return slots
+	return m
 }

--- a/route/websockets.go
+++ b/route/websockets.go
@@ -29,7 +29,7 @@ func (r *Request) Upgrade() *WebSocket {
 	}
 }
 
-func (ws *WebSocket) Discard() {
+func (ws *WebSocket) Discard(onclose func()) {
 	for {
 		if _, _, err := ws.conn.NextReader(); err != nil {
 			log.Infof("discarding message from ws client...")
@@ -37,8 +37,10 @@ func (ws *WebSocket) Discard() {
 			break
 		}
 	}
+	onclose()
 }
 
-func (ws *WebSocket) Write(b []byte) error {
-	return ws.conn.WriteMessage(websocket.TextMessage, b)
+func (ws *WebSocket) Write(b []byte) (bool, error) {
+	err := ws.conn.WriteMessage(websocket.TextMessage, b)
+	return !websocket.IsCloseError(err), err
 }


### PR DESCRIPTION
- We no longer leak file descriptors / goroutines for websocket clients
  who have gone away.

- We now get more metrics from `/v2/mbus/status`, regarding connections,
  message counts and payloads, etc.

I think this fixes some bizarre networking deadlock we saw on long-lived
(and much loved) SHIELD instances, in our lab.

Fixes #541