### PR TITLE
Mbus queues are buffered; sending events is async

### DIFF
--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -504,42 +504,45 @@ func (c *Core) v2API() *route.Router {
 			return
 		}
 
+		socket.SetWriteTimeout(45 * time.Second)
+
 		log.Infof("registering message bus web client")
 		ch, slot, err := c.bus.Register(queues)
 		if err != nil {
 			r.Fail(route.Oops(err, "Unable to begin streaming SHIELD events"))
 			return
 		}
-		log.Infof("registered with message bus as [slot:%d]", slot)
+		log.Infof("registered with message bus as [id:%d]", slot)
 
-		closeMeSoftly := func () {
-			defer recover()
-			close(ch)
-		}
+		closeMeSoftly := func() { c.bus.Unregister(slot) }
 		go socket.Discard(closeMeSoftly)
 		for event := range ch {
 			b, err := json.Marshal(event)
 			if err != nil {
-				log.Errorf("message bus web client [slot:%d] failed to marshal JSON for websocket relay: %s", slot, err)
+				log.Errorf("message bus web client [id:%d] failed to marshal JSON for websocket relay: %s", slot, err)
 			} else {
 				if done, err := socket.Write(b); done {
-					log.Infof("message bus web client [slot:%d] closed their end of the socket", slot)
-					log.Infof("message bus web client [slot:%d] shutting down", slot)
+					log.Infof("message bus web client [id:%d] closed their end of the socket", slot)
+					log.Infof("message bus web client [id:%d] shutting down", slot)
 					closeMeSoftly()
 					break
 				} else if err != nil {
-					log.Errorf("message bus web client [slot:%d] failed to write message to remote end: %s", slot, err)
-					log.Errorf("message bus web client [slot:%d] shutting down", slot)
+					log.Errorf("message bus web client [id:%d] failed to write message to remote end: %s", slot, err)
+					log.Errorf("message bus web client [id:%d] shutting down", slot)
 					closeMeSoftly()
+					err := socket.SendClose()
+					if err != nil {
+						log.Warnf("message bus web client [id:%d] failed to write close message")
+					}
 					break
 				}
 			}
 		}
 
-		log.Infof("message bus web client [slot:%d] disconnected; unregistering...", slot)
-		err = c.bus.Unregister(slot)
+		log.Infof("message bus web client [id:%d] disconnected; unregistering...", slot)
+		closeMeSoftly()
 		if err != nil {
-			log.Errorf("message bus web client [slot:%d] failed to unregister after disconnect: %s", slot, err)
+			log.Errorf("message bus web client [id:%d] failed to unregister after disconnect: %s", slot, err)
 		}
 	})
 	// }}}

--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -541,9 +541,6 @@ func (c *Core) v2API() *route.Router {
 
 		log.Infof("message bus web client [id:%d] disconnected; unregistering...", slot)
 		closeMeSoftly()
-		if err != nil {
-			log.Errorf("message bus web client [id:%d] failed to unregister after disconnect: %s", slot, err)
-		}
 	})
 	// }}}
 

--- a/core/bus/bus.go
+++ b/core/bus/bus.go
@@ -50,7 +50,7 @@ type slot struct {
 func New(n, backlog int) *Bus {
 	b := Bus{
 		slots:    make([]slot, n),
-		slotMap:  map[int64]int{},
+		slotMap:  make(map[int64]int, n),
 		backlog:  backlog,
 		events:   make(map[string]int64),
 		messages: make(map[string]int64),

--- a/core/bus/debug.go
+++ b/core/bus/debug.go
@@ -5,7 +5,7 @@ import "sort"
 type Metrics struct {
 	Configuration struct {
 		MaxSlots int `json:"max_slots"`
-		SlotSize int `json:"slot_size"`
+		Backlog  int `json:"backlog"`
 	} `json:"configuration"`
 	Connections struct {
 		Lifetime int64 `json:"lifetime"`
@@ -32,7 +32,7 @@ func (b *Bus) DumpState() Metrics {
 
 	var m Metrics
 	m.Configuration.MaxSlots = len(b.slots)
-	m.Configuration.SlotSize = b.chanLen
+	m.Configuration.Backlog = b.backlog
 	m.Connections.Lifetime = b.lifetime.connections
 	m.Connections.Current = b.current.connections
 	m.Connections.Dropped = b.dropped.connections

--- a/core/bus/debug.go
+++ b/core/bus/debug.go
@@ -1,14 +1,29 @@
 package bus
 
+import "sort"
+
 type Metrics struct {
+	Configuration struct {
+		MaxSlots int `json:"max_slots"`
+		SlotSize int `json:"slot_size"`
+	} `json:"configuration"`
 	Connections struct {
 		Lifetime int64 `json:"lifetime"`
 		Current  int64 `json:"current"`
+		Dropped  int64 `json:"dropped"`
 	} `json:"connections"`
 	Events   map[string]int64 `json:"events"`
 	Messages map[string]int64 `json:"messages"`
 
-	Slots [][]string `json:"clients"`
+	Slots []MetricSlot `json:"clients"`
+}
+
+type MetricSlot struct {
+	ID         int64    `json:"id"`
+	Queued     int      `json:"queued"`
+	MostQueued int      `json:"most_queued"`
+	Index      int      `json:"index"`
+	ACLs       []string `json:"acls"`
 }
 
 func (b *Bus) DumpState() Metrics {
@@ -16,8 +31,11 @@ func (b *Bus) DumpState() Metrics {
 	defer b.lock.Unlock()
 
 	var m Metrics
+	m.Configuration.MaxSlots = len(b.slots)
+	m.Configuration.SlotSize = b.chanLen
 	m.Connections.Lifetime = b.lifetime.connections
 	m.Connections.Current = b.current.connections
+	m.Connections.Dropped = b.dropped.connections
 
 	m.Events = make(map[string]int64)
 	for t, n := range b.events {
@@ -29,12 +47,23 @@ func (b *Bus) DumpState() Metrics {
 		m.Messages[t] = n
 	}
 
-	m.Slots = make([][]string, len(b.slots))
+	m.Slots = []MetricSlot{}
 	for i := range b.slots {
-		m.Slots[i] = make([]string, 0)
-		for q := range b.slots[i].acl {
-			m.Slots[i] = append(m.Slots[i], q)
+		if b.slots[i].ch == nil {
+			continue
 		}
+		m.Slots = append(m.Slots, MetricSlot{
+			Index:      i,
+			ID:         b.slots[i].id,
+			Queued:     len(b.slots[i].ch),
+			MostQueued: b.slots[i].mostQueued,
+			ACLs:       make([]string, 0, len(b.slots[i].acl)),
+		})
+		for q := range b.slots[i].acl {
+			m.Slots[i].ACLs = append(m.Slots[i].ACLs, q)
+		}
+
+		sort.Strings(m.Slots[i].ACLs)
 	}
 
 	return m

--- a/core/core.go
+++ b/core/core.go
@@ -108,6 +108,11 @@ type Config struct {
 		ca      string /* PEM-encoded contents */
 	} `yaml:"vault"`
 
+	Mbus struct {
+		MaxSlots int `yaml:"max-slots"`
+		SlotSize int `yaml:"slot-size"`
+	} `yaml:"mbus"`
+
 	Cipher string `yaml:"cipher"`
 
 	Bootstrapper string `yaml:"bootstrapper"`
@@ -144,6 +149,9 @@ func init() {
 	DefaultConfig.Cipher = "aes256-ctr"
 
 	DefaultConfig.Bootstrapper = "shield-restarter"
+
+	DefaultConfig.Mbus.MaxSlots = 2048
+	DefaultConfig.Mbus.SlotSize = 100
 }
 
 func Configure(file string, config Config) (*Core, error) {

--- a/core/core.go
+++ b/core/core.go
@@ -110,7 +110,7 @@ type Config struct {
 
 	Mbus struct {
 		MaxSlots int `yaml:"max-slots"`
-		SlotSize int `yaml:"slot-size"`
+		Backlog  int `yaml:"backlog"`
 	} `yaml:"mbus"`
 
 	Cipher string `yaml:"cipher"`
@@ -151,7 +151,7 @@ func init() {
 	DefaultConfig.Bootstrapper = "shield-restarter"
 
 	DefaultConfig.Mbus.MaxSlots = 2048
-	DefaultConfig.Mbus.SlotSize = 100
+	DefaultConfig.Mbus.Backlog = 100
 }
 
 func Configure(file string, config Config) (*Core, error) {

--- a/core/main.go
+++ b/core/main.go
@@ -258,7 +258,7 @@ func (c *Core) StartScheduler() {
 
 func (c *Core) ConfigureMessageBus() {
 	log.Infof("INITIALIZING: configuring message bus...")
-	c.bus = bus.New(2048)
+	c.bus = bus.New(c.Config.Mbus.MaxSlots, c.Config.Mbus.SlotSize)
 	c.db.Inform(c.bus)
 }
 

--- a/core/main.go
+++ b/core/main.go
@@ -257,8 +257,8 @@ func (c *Core) StartScheduler() {
 }
 
 func (c *Core) ConfigureMessageBus() {
-	log.Infof("INITIALIZING: configuring message bus...")
-	c.bus = bus.New(c.Config.Mbus.MaxSlots, c.Config.Mbus.SlotSize)
+	log.Infof("INITIALIZING: configuring message bus with %d slots and %d backlog per slot...")
+	c.bus = bus.New(c.Config.Mbus.MaxSlots, c.Config.Mbus.Backlog)
 	c.db.Inform(c.bus)
 }
 


### PR DESCRIPTION
Mbus channels have a buffer size - if a message is attempted to be put
in a full queue, the channel will be closed and the slot deregistered.
The buffer size is configurable as "slot-size". Additionally, the number
of slots that are initialized is now configurable as "max-slots".

Mbus event sends are asynchronous now. Calls to SendEvent should now
return in a predictable amount of time instead of potentially needing to
wait for a message to be read from a channel synchronisly.

The mbus/status endpoint has been altered: it only lists the slots that
are active at that moment (to avoid dumping 2047 empty slots, for
example). Each slot reports its current channel len and high watermark
channel length now. The status also reports the configuration of the
mbus as a whole.

Register now returns a unique ID instead of the slot index. This allows
calls to Unregister to be idempotent, which allows users of the mbus to
more realistically allow the mbus to handle all cases of the closing of
the message channel (through Unregister). Because Unregister can be
synchronized with other channel accesses (because its owned by the Mbus
object), we eliminate the possibility of send/close races, leading to
less requirements to recover from panics.

The API now attempts to be nice and send a close message to the client
in the case of a write error, giving the client a suggestion to
dis/reconnect. Without this, the client may be unaware of the write
error, and may keepalive the connection with the belief that more
messages are en-route someday. The close message can timeout on send -
it is only a best effort attempt to guide the client towards the correct
behavior.

Websocket message writes now have a timeout. It is currently hardcoded
to 45 seconds, but someday can be made configurable if necessary. In the
case of a write timeout, the queue is Unregistered and a close message
is attempted to be sent to the client.

The Write function now properly reports when a websocket has been closed.

Additional work likely needs to be done on the web UI side to make it
better at reconnecting in the case of a closed websocket, but these
changes should cause a websocket to be closed when conditions become
bad, and also allow SHIELD to continue working normally in the case of a
single bad websocket client.