### PR TITLE
Fix Websocket timeouts

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -65,6 +65,15 @@ type Config struct {
 			Password string `yaml:"password"`
 		} `yaml:"failsafe"`
 
+		Websocket struct {
+			//WriteTimeout is the time allowed for each WebSocket message to be
+			// written, in seconds. If a deadline is missed, the connection is
+			// terminated.
+			WriteTimeout int `yaml:"write-timeout"`
+			//PingInteval is the time between WebSocket Ping messages, in seconds
+			PingInterval int `yaml:"ping-interval"`
+		} `yaml:"websocket"`
+
 		Env   string `yaml:"env"`
 		Color string `yaml:"color"`
 		MOTD  string `yaml:"motd"`
@@ -141,6 +150,9 @@ func init() {
 	DefaultConfig.API.Env = "SHIELD"
 	DefaultConfig.API.Color = "yellow"
 
+	DefaultConfig.API.Websocket.WriteTimeout = 45
+	DefaultConfig.API.Websocket.PingInterval = 30
+
 	DefaultConfig.Limit.Retention.Min = 1
 	DefaultConfig.Limit.Retention.Max = 390
 
@@ -190,6 +202,22 @@ func Configure(file string, config Config) (*Core, error) {
 
 	if c.Config.API.Session.Timeout <= 0 {
 		return nil, fmt.Errorf("api.session.timeout of '%d' hours is invalid (must be greater than zero)", c.Config.API.Session.Timeout)
+	}
+
+	if c.Config.API.Websocket.PingInterval <= 0 {
+		return nil, fmt.Errorf("api.websocket.ping-interval of '%d' seconds is invalid (must be greater than zero)", c.Config.API.Websocket.PingInterval)
+	}
+
+	if c.Config.API.Websocket.WriteTimeout <= 0 {
+		return nil, fmt.Errorf("api.websocket.write-timeout of '%d' seconds is invalid (must be greater than zero)", c.Config.API.Websocket.WriteTimeout)
+	}
+
+	if c.Config.Mbus.MaxSlots <= 0 {
+		return nil, fmt.Errorf("mbus.max-slots of '%d' is invalid (must be greater than zero)", c.Config.Mbus.MaxSlots)
+	}
+
+	if c.Config.Mbus.Backlog < 0 {
+		return nil, fmt.Errorf("mbus.backlog of '%d' is invalid (must be a positive integer)", c.Config.Mbus.Backlog)
 	}
 
 	if c.Config.Cipher == "" {

--- a/web/htdocs/js/data.js
+++ b/web/htdocs/js/data.js
@@ -106,6 +106,16 @@
       return this;
     },
 
+		clear: function (type, object) {
+			this.data = {};
+			this.grants.tenant = {}
+			this.grants.system = {
+				admin:    false,
+				manager:  false,
+				engineer: false
+			}
+		}
+
     delete: function (type, object) {
       delete this.data[type][object.uuid];
     },
@@ -378,6 +388,7 @@
       this.ws.onclose = function () {
         self.ws = undefined;
         df.reject();
+        self.subscribe()
       };
 
       this.ws.onmessage = function (m) {
@@ -420,6 +431,7 @@
 
       this.ws.onopen = function () {
         console.log('connected to event stream.');
+        self.clear()
         console.log('getting our bearings (via %s)...', opts.bearings);
         api({
           type: 'GET',


### PR DESCRIPTION
The server now sends keepalive messages after a configurable timeout
interval if a message has not been sent during that time. This should
keep the connection open even if there are no events to send.

The write timeout for messages is now configurable.

The configuration will now error if mbus parameters are negative.