### PR TITLE
Environmental Configuration of SHIELD

### DIFF
--- a/bin/testdev
+++ b/bin/testdev
@@ -242,103 +242,37 @@ EOF
 (shieldd)
   ssh-keygen -m PEM -t rsa -f ${workdir}/config/shieldd_key -N '' >/dev/null
   rm ${workdir}/config/shieldd_key.pub
-  legacy_ssh_key=$(cat ${workdir}/config/shieldd_key | sed -e 's/^/      /')
 
-  cat >${workdir}/etc/shieldd.conf <<EOF
----
-debug:    true
-data-dir: ${workdir}/var/
-web-root: ./web/htdocs
-plugin_paths:
-  - ${workdir}/bin
-
-scheduler:
-  fast-loop: 5
-  slow-loop: 40
-
-api:
-  bind: 127.0.0.1:8180
-  pprof: ':8185'
-  env:   TESTDEV
-  color: yellow
-  motd: |
-    Welcome to the testdev S.H.I.E.L.D. environment!
-
-  failsafe:
-    username: failsafe
-    password: sekrit
-
-  session:
-    timeout: 8
-
-fabrics:
-  - name: legacy
-    ssh-key: |
-${legacy_ssh_key}
-
-auth:
-  - name:       Github
-    identifier: github
-    backend:    github
-    properties:
-      client_id:     35f670b0ee9c9b4bc37c
-      client_secret: b33d1309ea69e75c0ccd51f2caac9493e9326830
-      mapping:
-        - github: starkandwayne  # <-- github org name
-          tenant: starkandwayne  # <-- shield tenant name
-          rights:
-            - team: Owners       # <-- github team name
-              role: admin        # <-- shield role name
-            - team: Engineering  #   (first match wins)
-              role: engineer
-            - role: operator     # = (default match)
-
-        - github: starkandwayne
-          tenant: SYSTEM
-          rights:
-            - team: Engineering
-              role: admin
-
-        - github: cloudfoundry-community
-          tenant: CF Community
-          rights:
-            - role: engineer
-
-  - name:       UAA
-    identifier: uaa1
-    backend:    uaa
-    properties:
-      client_id:       shield-dev
-      client_secret:   s.h.i.e.l.d.
-      uaa_endpoint:    https://uaa.shield.10.244.156.2.netip.cc:8443
-      skip_verify_tls: true
-      mapping:
-        - tenant: UAA          # <-- shield tenant name
-          rights:
-            - scim: uaa.admin  # <-- uaa scim right
-              role: admin      # <-- shield role
-                               #   (first match wins)
-            - scim: cloud_controller.write
-              role: engineer
-
-            - role: operator   # = (default match)
-
-        - tenant: UAA Admins Club
-          rights:
-            - scim: uaa.admin
-              role: admin
-
-EOF
+  export SHIELD_DEBUG=yes
+  export SHIELD_LOG_LEVEL=debug
+  export SHIELD_DATA_DIR="${workdir}/var/"
+  export SHIELD_WEB_ROOT="${PWD}/web/htdocs"
+  export SHIELD_SCHEDULER_FAST_LOOP=5
+  export SHIELD_SCHEDULER_SLOW_LOOP=40
+  export SHIELD_API_BIND="127.0.0.1:8180"
+  export SHIELD_API_PPROF=":8185"
+  export SHIELD_API_ENV="TESTDEV"
+  export SHIELD_API_COLOR="yellow"
+  export SHIELD_API_MOTD="Welcome to the testdev S.H.I.E.L.D. environment!"
+  export SHIELD_API_FAILSAFE_USERNAME="failsafe"
+  export SHIELD_API_FAILSAFE_PASSWORD="sekrit"
+  export SHIELD_API_SESSION_TIMEOUT=8
+  export SHIELD_LEGACY_AGENTS_ENABLED=yes
+  export SHIELD_LEGACY_AGENTS_DIAL_TIMEOUT=5
+  export SHIELD_LEGACY_AGENTS_PRIVATE_KEY=$(cat ${workdir}/config/shieldd_key)
+  export SHIELD_PLUGIN_PATHS="${workdir}/bin"
 
   export PATH=$(pwd):$(pwd)/bin:${PATH}
   while true; do
+    env | grep ^SHIELD_
+    echo
     echo ">> Setting up SHIELD schema"
     ./shield-schema -d ${workdir}/var/shield.db
     echo
 
-    echo ">> RUNNING SHIELDD"
+    echo ">> RUNNING SHIELD CORE"
     trap ":" INT # ignore Ctrl-C
-    GODEBUG=schedtrace=1000 ./shieldd -c ${workdir}/etc/shieldd.conf --log-level debug 2>&1 | tee ${workdir}/var/shieldd.log
+    GODEBUG=schedtrace=1000 ./shieldd 2>&1 | tee ${workdir}/var/shieldd.log
     echo
     echo "shieldd exited."
     echo "Do you want to restart it?"
@@ -357,29 +291,21 @@ EOF
       sleep 1
   done
 
-  ssh-keygen -m PEM -t rsa -f ${workdir}/var/shield-agent_key -N '' >/dev/null
-  rm ${workdir}/var/shield-agent_key.pub
-
-  `curl -XGET -H "X-Shield-Session: ${SHIELD_API_TOKEN}" http://127.0.0.1:${PORT}/v1/meta/pubkey >> ${workdir}/var/authorized_keys`
-  cat >${workdir}/etc/shield-agent.conf <<EOF
----
-authorized_keys_file: ${workdir}/var/authorized_keys
-host_key_file: ${workdir}/var/shield-agent_key
-listen_address: 0.0.0.0:5444
-plugin_paths:
-  - ${workdir}/bin
-
-name: bond-james-bond
-registration:
-  url: http://localhost:${PORT}
-  interval: 15
-EOF
+  export SHIELD_AGENT_NAME="bond-james-bond"
+  export SHIELD_AGENT_LISTEN_ADDRESS="0.0.0.0:5444"
+  export SHIELD_AGENT_LOG_LEVEL=debug
+  export SHIELD_AGENT_REGISTRATION_URL="http://127.0.0.1:${PORT}"
+  export SHIELD_AGENT_REGISTRATION_INTERVAL=15
+  export SHIELD_AGENT_AUTHORIZED_KEY=$(curl -H "X-Shield-Session: ${SHIELD_API_TOKEN}" ${SHIELD_AGENT_REGISTRATION_URL}/v1/meta/pubkey)
+  export SHIELD_AGENT_PLUGIN_PATHS="${workdir}/bin"
 
   export PATH=$(pwd):$(pwd)/bin:${PATH}
   while true; do
+    env | grep ^SHIELD_
+    echo
     echo ">> RUNNING SHIELD AGENT"
     trap ":" INT # ignore Ctrl-C
-    ./shield-agent -c ${workdir}/etc/shield-agent.conf --log-level debug 2>&1 | tee ${workdir}/var/shield-agent.log
+    ./shield-agent 2>&1 | tee ${workdir}/var/shield-agent.log
     echo
     echo "shield-agent exited."
     echo "Do you want to restart it?"

--- a/cmd/shield-agent/main.go
+++ b/cmd/shield-agent/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/jhunt/go-cli"
+	env "github.com/jhunt/go-envirotron"
 	"github.com/jhunt/go-log"
 
 	"github.com/shieldproject/shield/agent"
@@ -17,10 +18,11 @@ func main() {
 		Help    bool `cli:"-h, --help"`
 		Version bool `cli:"-v, --version"`
 
-		ConfigFile string `cli:"-c, --config"`
-		Log        string `cli:"-l, --log-level"`
+		ConfigFile string `cli:"-c, --config"    env:"SHIELD_AGENT_CONFIG_FILE"`
+		Log        string `cli:"-l, --log-level" env:"SHIELD_AGENT_LOG_LEVEL"`
 	}
 	opts.Log = "info"
+	env.Override(&opts)
 
 	_, args, err := cli.Parse(&opts)
 	if err != nil {
@@ -51,11 +53,6 @@ func main() {
 			fmt.Printf("shield-agent v%s\n", Version)
 		}
 		os.Exit(0)
-	}
-
-	if opts.ConfigFile == "" {
-		fmt.Fprintf(os.Stderr, "You must specify a configuration file via `--config`\n")
-		os.Exit(1)
 	}
 
 	log.SetupLogging(log.LogConfig{

--- a/cmd/shieldd/main.go
+++ b/cmd/shieldd/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/jhunt/go-cli"
+	env "github.com/jhunt/go-envirotron"
 	"github.com/jhunt/go-log"
 
 	// sql drivers
@@ -22,10 +23,11 @@ func main() {
 		Help    bool `cli:"-h, --help"`
 		Version bool `cli:"-v, --version"`
 
-		ConfigFile string `cli:"-c, --config"`
-		Log        string `cli:"-l, --log-level"`
+		ConfigFile string `cli:"-c, --config"    env:"SHIELD_CONFIG_FILE"`
+		Log        string `cli:"-l, --log-level" env:"SHIELD_LOG_LEVEL"`
 	}
 	opts.Log = "info"
+	env.Override(&opts)
 
 	_, args, err := cli.Parse(&opts)
 	if err != nil {

--- a/core/api_v1.go
+++ b/core/api_v1.go
@@ -10,13 +10,10 @@ func (c *Core) v1API() *route.Router {
 	}
 
 	r.Dispatch("GET /v1/meta/pubkey", func(r *route.Request) {
-		for _, fc := range c.Config.Fabrics {
-			if fc.Name == "legacy" {
-				r.Respond(200, "text/plain", "%s\n", fc.legacy.pub)
-				return
-			}
+		if !c.Config.LegacyAgents.Enabled {
+			r.Respond(403, "text/plain", "# legacy agent communication disabled.\n")
 		}
-		r.Respond(404, "text/plain", "# no legacy fabric(s) configured!\n")
+		r.Respond(200, "text/plain", "%s\n", c.Config.LegacyAgents.pub)
 	})
 
 	return r

--- a/core/core.go
+++ b/core/core.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
+	env "github.com/jhunt/go-envirotron"
 	"github.com/jhunt/go-log"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
@@ -39,49 +41,50 @@ type Core struct {
 }
 
 type Config struct {
-	Debug       bool     `yaml:"debug"`
-	DataDir     string   `yaml:"data-dir"`
-	WebRoot     string   `yaml:"web-root"`
-	PluginPaths []string `yaml:"plugin_paths"`
+	Debug          bool     `yaml:"debug"          env:"SHIELD_DEBUG"`
+	DataDir        string   `yaml:"data-dir"       env:"SHIELD_DATA_DIR"`
+	WebRoot        string   `yaml:"web-root"       env:"SHIELD_WEB_ROOT"`
+	PluginPaths    []string `yaml:"plugin_paths"`
+	PluginPathsEnv string   `yaml:"-"              env:"SHIELD_PLUGIN_PATHS"`
 
 	Scheduler struct {
-		FastLoop int `yaml:"fast-loop"`
-		SlowLoop int `yaml:"slow-loop"`
-		Threads  int `yaml:"threads"`
-		Timeout  int `yaml:"timeout"`
+		FastLoop int `yaml:"fast-loop" env:"SHIELD_SCHEDULER_FAST_LOOP"`
+		SlowLoop int `yaml:"slow-loop" env:"SHIELD_SCHEDULER_SLOW_LOOP"`
+		Threads  int `yaml:"threads"   env:"SHIELD_SCHEDULER_THREADS"`
+		Timeout  int `yaml:"timeout"   env:"SHIELD_SCHEDULER_TIMEOUT"`
 	} `yaml:"scheduler"`
 
 	API struct {
-		Bind    string `yaml:"bind"`
-		PProf   string `yaml:"pprof"`
+		Bind    string `yaml:"bind"  env:"SHIELD_API_BIND"`
+		PProf   string `yaml:"pprof" env:"SHIELD_API_PPROF"`
 		Session struct {
-			ClearOnBoot bool `yaml:"clear-on-boot"`
-			Timeout     int  `yaml:"timeout"`
+			ClearOnBoot bool `yaml:"clear-on-boot" env:"SHIELD_API_SESSION_CLEAR_ON_BOOT"`
+			Timeout     int  `yaml:"timeout"       env:"SHIELD_API_SESSION_TIMEOUT"`
 		} `yaml:"session"`
 
 		Failsafe struct {
-			Username string `yaml:"username"`
-			Password string `yaml:"password"`
+			Username string `yaml:"username" env:"SHIELD_API_FAILSAFE_USERNAME"`
+			Password string `yaml:"password" env:"SHIELD_API_FAILSAFE_PASSWORD"`
 		} `yaml:"failsafe"`
 
 		Websocket struct {
 			//WriteTimeout is the time allowed for each WebSocket message to be
 			// written, in seconds. If a deadline is missed, the connection is
 			// terminated.
-			WriteTimeout int `yaml:"write-timeout"`
+			WriteTimeout int `yaml:"write-timeout" env:"SHIELD_API_WEBSOCKET_WRITE_TIMEOUT"`
 			//PingInteval is the time between WebSocket Ping messages, in seconds
-			PingInterval int `yaml:"ping-interval"`
+			PingInterval int `yaml:"ping-interval" env:"SHIELD_API_WEBSOCKET_PING_INTERVAL"`
 		} `yaml:"websocket"`
 
-		Env   string `yaml:"env"`
-		Color string `yaml:"color"`
-		MOTD  string `yaml:"motd"`
+		Env   string `yaml:"env"   env:"SHIELD_API_ENV"`
+		Color string `yaml:"color" env:"SHIELD_API_COLOR"`
+		MOTD  string `yaml:"motd"  env:"SHIELD_API_MOTD"`
 	} `yaml:"api"`
 
 	Limit struct {
 		Retention struct {
-			Min int `yaml:"min"`
-			Max int `yaml:"max"`
+			Min int `yaml:"min" env:"SHIELD_LIMIT_RETENTION_MIN"`
+			Max int `yaml:"max" env:"SHIELD_LIMIT_RETENTION_MAX"`
 		} `yaml:"retention"`
 	} `yaml:"limit"`
 
@@ -93,37 +96,28 @@ type Config struct {
 		Properties map[interface{}]interface{} `yaml:"properties"`
 	} `yaml:"auth"`
 
-	Fabrics []struct {
-		Name string `yaml:"name"`
+	LegacyAgents struct {
+		Enabled     bool   `yaml:"enabled"      env:"SHIELD_LEGACY_AGENTS_ENABLED"`
+		PrivateKey  string `yaml:"private-key"  env:"SHIELD_LEGACY_AGENTS_PRIVATE_KEY"`
+		DialTimeout int    `yaml:"dial-timeout" env:"SHIELD_LEGACY_AGENTS_DIAL_TIMEOUT"`
 
-		Delay int `yaml:"delay"`
-
-		SSHKey string `yaml:"ssh-key"`
-
-		//A value of zero means no timeout - the timeout will fall back to when
-		// the system drops the connection
-		SSHDialTimeout *int `yaml:"ssh-dial-timeout"`
-
-		legacy struct {
-			cc  *ssh.ClientConfig
-			pub string
-		}
-	} `yaml:"fabrics"`
+		cc  *ssh.ClientConfig
+		pub string
+	} `yaml:"legacy-agents"`
 
 	Vault struct {
-		Address string `yaml:"address"`
-		CACert  string `yaml:"ca"`
-		ca      string /* PEM-encoded contents */
+		Address string `yaml:"address" env:"SHIELD_VAULT_ADDRESS"`
+		CACert  string `yaml:"ca" env:"SHIELD_VAULT_CA"`
 	} `yaml:"vault"`
 
 	Mbus struct {
-		MaxSlots int `yaml:"max-slots"`
-		Backlog  int `yaml:"backlog"`
+		MaxSlots int `yaml:"max-slots" env:"SHIELD_MBUS_MAX_SLOTS"`
+		Backlog  int `yaml:"backlog"   env:"SHIELD_MBUS_BACKLOG"`
 	} `yaml:"mbus"`
 
-	Cipher string `yaml:"cipher"`
+	Cipher string `yaml:"cipher" env:"SHIELD_CIPHER"`
 
-	Bootstrapper string `yaml:"bootstrapper"`
+	Bootstrapper string `yaml:"bootstrapper" env:"SHIELD_BOOTSTRAPPER"`
 }
 
 var (
@@ -134,7 +128,7 @@ var (
 func init() {
 	DefaultConfig.DataDir = "/shield/data"
 	DefaultConfig.WebRoot = "/shield/ui"
-	DefaultConfig.PluginPaths = []string{"/shield/plugins"}
+	DefaultConfig.PluginPathsEnv = "/shield/plugins"
 
 	DefaultConfig.Scheduler.FastLoop = 1
 	DefaultConfig.Scheduler.SlowLoop = 300
@@ -155,6 +149,9 @@ func init() {
 	DefaultConfig.Limit.Retention.Min = 1
 	DefaultConfig.Limit.Retention.Max = 390
 
+	DefaultConfig.LegacyAgents.Enabled = true
+	DefaultConfig.LegacyAgents.DialTimeout = 30
+
 	DefaultConfig.Vault.Address = "http://127.0.0.1:8200"
 
 	DefaultConfig.Cipher = "aes256-ctr"
@@ -167,6 +164,7 @@ func init() {
 
 func Configure(file string, config Config) (*Core, error) {
 	c := &Core{Config: config}
+	env.Override(&c.Config)
 
 	if file != "" {
 		b, err := ioutil.ReadFile(file)
@@ -241,6 +239,13 @@ func Configure(file string, config Config) (*Core, error) {
 		return nil, fmt.Errorf("SHIELD web root directory '%s' is invalid (not a directory)", c.Config.WebRoot)
 	}
 
+	if c.Config.PluginPathsEnv != "" {
+		p := strings.Split(c.Config.PluginPathsEnv, ":")
+		for _, path := range c.Config.PluginPaths {
+			p = append(p, path)
+		}
+		c.Config.PluginPaths = p
+	}
 	for _, path := range c.Config.PluginPaths {
 		if path == "" {
 			return nil, fmt.Errorf("SHIELD plugin directory '%s' is invalid (must be a valid path)", path)
@@ -253,50 +258,37 @@ func Configure(file string, config Config) (*Core, error) {
 	}
 
 	if c.Config.Vault.CACert != "" {
-		b, err := ioutil.ReadFile(c.Config.Vault.CACert)
-		if err != nil {
-			return nil, fmt.Errorf("Unable to read Vault CA Certificate '%s': %s", c.Config.Vault.CACert, err)
-		}
-		c.Config.Vault.ca = string(b)
-	}
-
-	/* validate fabrics */
-	if len(c.Config.Fabrics) == 0 {
-		return nil, fmt.Errorf("No agent comunication fabrics have been configured")
-	}
-	for i, fc := range c.Config.Fabrics {
-		switch fc.Name {
-		default:
-			return nil, fmt.Errorf("Unrecognized fabric '%s' configured", fc.Name)
-
-		case "legacy":
-			if fc.SSHKey == "" {
-				return nil, fmt.Errorf("No ssh-key provided in legacy fabric configuration")
-			}
-
-			signer, err := ssh.ParsePrivateKey([]byte(fc.SSHKey))
+		if !strings.HasPrefix(c.Config.Vault.CACert, "---") {
+			b, err := ioutil.ReadFile(c.Config.Vault.CACert)
 			if err != nil {
-				return nil, fmt.Errorf("Invalid 'ssh-key' provided in legacy fabric configuration: %s", err)
+				return nil, fmt.Errorf("Unable to read Vault CA Certificate '%s': %s", c.Config.Vault.CACert, err)
 			}
-			c.Config.Fabrics[i].legacy.pub = fmt.Sprintf("%s %s",
-				signer.PublicKey().Type(),
-				base64.StdEncoding.EncodeToString(signer.PublicKey().Marshal()))
+			c.Config.Vault.CACert = string(b)
+		}
+	}
 
-			timeout := 30 * time.Second
-			if c.Config.Fabrics[i].SSHDialTimeout != nil {
-				timeout = time.Duration(*(c.Config.Fabrics[i].SSHDialTimeout)) * time.Second
-			}
+	if !c.Config.LegacyAgents.Enabled {
+		return nil, fmt.Errorf("Agent communication has been disabled.  Please set legacy-agents.enabled to 'yes'")
+	}
+	if c.Config.LegacyAgents.Enabled {
+		if c.Config.LegacyAgents.PrivateKey == "" {
+			return nil, fmt.Errorf("No SSH private key provided for communicating with legacy agents")
+		}
+		signer, err := ssh.ParsePrivateKey([]byte(c.Config.LegacyAgents.PrivateKey))
+		if err != nil {
+			return nil, fmt.Errorf("Invalid SSH private key provided for communicating with legacy agents: %s", err)
+		}
+		c.Config.LegacyAgents.pub = fmt.Sprintf("%s %s",
+			signer.PublicKey().Type(),
+			base64.StdEncoding.EncodeToString(signer.PublicKey().Marshal()))
 
-			c.Config.Fabrics[i].legacy.cc = &ssh.ClientConfig{
-				Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-				Timeout:         timeout,
-			}
-
-		case "dummy":
-			if len(c.Config.Fabrics) != 1 {
-				return nil, fmt.Errorf("The dummy fabric cannot coexist with any other fabric; it is for test/dev only")
-			}
+		if c.Config.LegacyAgents.DialTimeout < 0 {
+			return nil, fmt.Errorf("Invalid connection timeout provided for communicating with legacy agents: %d is less than 0", c.Config.LegacyAgents.DialTimeout)
+		}
+		c.Config.LegacyAgents.cc = &ssh.ClientConfig{
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			Timeout:         time.Duration(c.Config.LegacyAgents.DialTimeout) * time.Second,
 		}
 	}
 
@@ -395,18 +387,5 @@ func (c *Core) CryptFile() string {
 }
 
 func (c *Core) FabricFor(task *db.Task) (fabric.Fabric, error) {
-	for _, config := range c.Config.Fabrics {
-		if config.Name == "dummy" {
-			/* if dummy is configured, we always use it (test/dev) */
-			return fabric.Dummy(config.Delay), nil
-		}
-
-		if config.Name != "legacy" {
-			continue
-		}
-
-		return fabric.Legacy(task.Agent, config.legacy.cc, c.db), nil
-	}
-
-	return nil, fmt.Errorf("no fabric configured to handle agent '%s'", task.Agent)
+	return fabric.Legacy(task.Agent, c.Config.LegacyAgents.cc, c.db), nil
 }

--- a/core/main.go
+++ b/core/main.go
@@ -203,7 +203,7 @@ func (c *Core) CleanupLeftoverTasks() {
 func (c *Core) ConnectToVault() {
 	log.Infof("INITIALIZING: connecting to the local SHIELD vault...")
 
-	v, err := vault.Connect(c.Config.Vault.Address, c.Config.Vault.ca)
+	v, err := vault.Connect(c.Config.Vault.Address, c.Config.Vault.CACert)
 	c.MaybeTerminate(err)
 
 	status, err := v.Status()

--- a/init/core
+++ b/init/core
@@ -20,7 +20,7 @@ if [[ ! -f "${SHIELD_ETC}/ssh.key" ]]; then
   rm -f "${SHIELD_ETC}/ssh.key.pub"
 fi
 
-if [[ ! -f "${SHIELD_ETC}/shieldd.conf" ]]; then
+if [[ ! -f "${SHIELD_ETC}/shieldd.conf" && -z ${SHIELD_LEGACY_AGENTS_PRIVATE_KEY:-} ]]; then
   legacy_ssh_key=$(cat ${SHIELD_ETC}/ssh.key | sed -e 's/^/      /')
 
   cat > "${SHIELD_ETC}/shieldd.conf" <<EOF


### PR DESCRIPTION
This changeset allows the SHIELD Core (shieldd) and the SHIELD Agent
(shield-agent) to be configured completely (minus auth providers) via
environment variables.  This is all but required for running SHIELD
effectively in Docker, Docker Compose, and Kubernetes.

To do so, I also had to incorporate changes requested in #618, to remove
the variable-length `fabrics:` configuration.

`bin/testdev` has been updated to incorporate an environment-first
approach, as a proof-of-concept.

Fixes #618.