### PR TITLE
Archive status updates in real time when an archive is purged

### DIFF
--- a/db/archives.go
+++ b/db/archives.go
@@ -269,7 +269,7 @@ func (db *DB) GetArchive(id string) (*Archive, error) {
 func (db *DB) CreateArchiveFromTask(task_uuid string, archive Archive) (*Archive, error) {
 	var out *Archive
 
-	err := db.exclusively(func () error {
+	err := db.exclusively(func() error {
 		err := db.exec(`
                   INSERT INTO archives
                     (uuid, target_uuid, store_uuid, store_key, taken_at,
@@ -359,7 +359,18 @@ func (db *DB) ExpireArchive(id string) error {
 }
 
 func (db *DB) ManuallyPurgeArchive(id string) error {
-	return db.Exec(`UPDATE archives SET status = 'manually purged' WHERE uuid = ?`, id)
+	err := db.Exec(`UPDATE archives SET status = 'manually purged' WHERE uuid = ?`, id)
+	if err != nil {
+		return err
+	}
+
+	archive, err := db.getArchive(id)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve archive [%s]: %s", id, err)
+	}
+	db.sendUpdateObjectEvent(archive, "tenant:"+archive.TenantUUID)
+
+	return err
 }
 
 func (db *DB) DeleteArchive(id string) (bool, error) {

--- a/db/archives.go
+++ b/db/archives.go
@@ -359,7 +359,7 @@ func (db *DB) ExpireArchive(id string) error {
 }
 
 func (db *DB) ManuallyPurgeArchive(id string) error {
-	err := db.exclusively(func() error {
+	return db.exclusively(func() error {
 		err := db.exec(`UPDATE archives SET status = 'manually purged' WHERE uuid = ?`, id)
 		if err != nil {
 			return err
@@ -370,11 +370,8 @@ func (db *DB) ManuallyPurgeArchive(id string) error {
 			return fmt.Errorf("unable to retrieve archive [%s]: %s", id, err)
 		}
 		db.sendUpdateObjectEvent(archive, "tenant:"+archive.TenantUUID)
-
-		return err
+		return nil
 	})
-
-	return err
 }
 
 func (db *DB) DeleteArchive(id string) (bool, error) {

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -1038,13 +1038,13 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
                            }
                          }
                     ]]
-                    <tr class="[[ if (!target.healthy) { ]]fail[[ } else { ]]ok[[ } ]][[ if (h(n) == 0) { ]] no-archive not-selectable[[ } ]]"
+                    <tr class="[[ if (!target.healthy) { ]]fail[[ } else { ]]ok[[ } ]][[ if (n == 0) { ]] no-archive not-selectable[[ } ]]"
                         data-target-uuid="[[= target.uuid ]]">
                       <td class="name">
                         <img src="i/shield-[[= target.healthy ? 'ok' : 'fail' ]].svg">
                         [[= h(target.name) ]]
                       </td>
-                      <td>[[ if (h(n) == 0) { ]]<em>none</em>[[ } else { ]][[= h(n) ]][[ } ]]</td>
+                      <td>[[ if (n == 0) { ]]<em>none</em>[[ } else { ]][[= n ]][[ } ]]</td>
                       <td>[[= h(target.plugin) ]]</td>
                       <td class="notes">
                         [[= md(target.summary) ]]

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -1031,14 +1031,20 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
                     [[ $.each(systems, function (i, target) {
                          var archives = AEGIS.archives({ tenant: target.tenant_uuid,
                                                          system: target.uuid });
+                         var n = 0;
+                         for(var archive of archives) {
+                           if(archive.status == "valid") {
+                             n++;
+                           }
+                         }
                     ]]
-                    <tr class="[[ if (!target.healthy) { ]]fail[[ } else { ]]ok[[ } ]][[ if (archives.length == 0) { ]] no-archive not-selectable[[ } ]]"
+                    <tr class="[[ if (!target.healthy) { ]]fail[[ } else { ]]ok[[ } ]][[ if (h(n) == 0) { ]] no-archive not-selectable[[ } ]]"
                         data-target-uuid="[[= target.uuid ]]">
                       <td class="name">
                         <img src="i/shield-[[= target.healthy ? 'ok' : 'fail' ]].svg">
                         [[= h(target.name) ]]
                       </td>
-                      <td>[[ if (archives.length == 0) { ]]<em>none</em>[[ } else { ]][[= archives.length ]][[ } ]]</td>
+                      <td>[[ if (h(n) == 0) { ]]<em>none</em>[[ } else { ]][[= h(n) ]][[ } ]]</td>
                       <td>[[= h(target.plugin) ]]</td>
                       <td class="notes">
                         [[= md(target.summary) ]]
@@ -1919,8 +1925,10 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
                  $.each(AEGIS.archives({ tenant: target.tenant_uuid,
                                          system: target.uuid }),
                         function (i, archive) {
-                          n++;
-                          used += archive.size;
+                          if (archive.status == "valid") {
+                            n++;
+                            used += archive.size;
+                          }
                         }); ]]
               <dl>
                 <dt>Backup Archives</dt>
@@ -1979,6 +1987,7 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
               </tr></thead>
               <tbody>
                 [[ $.each(show, function (i, archive) { ]]
+                  [[ if (archive.status == "valid") { ]]
                 <tr data-archive-uuid="[[= archive.uuid ]]">
                   <td class="uuid">[[= archive.uuid.substr(0,8) ]]</td>
                   <td class="date" data-sort-as="number" data-sort="[[= archive.taken_at ]]">
@@ -1989,8 +1998,9 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
                   [[ var store = AEGIS.store(archive.store_uuid); ]]
                   <td>[[= store.name ]] ([[= store.plugin ]])</td>
                   <td>[[= archive.status ]]</td>
-                  <td>[[ if (archive.status == "valid") { ]]<a href="restore:[[= archive.uuid ]]">restore</a>[[ } ]]</td>
+                  <td><a href="restore:[[= archive.uuid ]]">restore</a></td>
                 </tr>
+                  [[ } ]]
                 [[ }); ]]
               </tbody>
             </table>


### PR DESCRIPTION
When an archive is purged. It updates the count in the data systems page and removes the archive from the list of valid archives without reloading the page. Fixes #617 