### PR TITLE
Purge old task logs / archives

### DIFF
--- a/bin/testdev
+++ b/bin/testdev
@@ -261,6 +261,8 @@ EOF
   export SHIELD_LEGACY_AGENTS_DIAL_TIMEOUT=5
   export SHIELD_LEGACY_AGENTS_PRIVATE_KEY=$(cat ${workdir}/config/shieldd_key)
   export SHIELD_PLUGIN_PATHS="${workdir}/bin"
+  export SHIELD_METADATA_RETENTION_PURGED_ARCHIVES="90s"
+  export SHIELD_METADATA_RETENTION_TASK_LOGS="1h"
 
   export PATH=$(pwd):$(pwd)/bin:${PATH}
   while true; do

--- a/core/core.go
+++ b/core/core.go
@@ -88,6 +88,13 @@ type Config struct {
 		} `yaml:"retention"`
 	} `yaml:"limit"`
 
+	Metadata struct {
+		Retention struct {
+			PurgedArchives duration `yaml:"purged_archives" env:"SHIELD_METADATA_RETENTION_PURGED_ARCHIVES"`
+			TaskLogs       duration `yaml:"task_logs"       env:"SHIELD_METADATA_RETENTION_TASK_LOGS"`
+		} `yaml:"retention"`
+	} `yaml:"metadata"`
+
 	Auth []struct {
 		Name       string `yaml:"name"`
 		Identifier string `yaml:"identifier"`
@@ -148,6 +155,9 @@ func init() {
 
 	DefaultConfig.Limit.Retention.Min = 1
 	DefaultConfig.Limit.Retention.Max = 390
+
+	DefaultConfig.Metadata.Retention.PurgedArchives = 60 * 60 * 24 * 90
+	DefaultConfig.Metadata.Retention.TaskLogs = 60 * 60 * 24 * 90
 
 	DefaultConfig.LegacyAgents.Enabled = true
 	DefaultConfig.LegacyAgents.DialTimeout = 30

--- a/core/duration.go
+++ b/core/duration.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var durationPattern *regexp.Regexp
+
+func init() {
+	durationPattern = regexp.MustCompile(`^(?i)(\d+(?:\.\d+)?)\s?([Ywdhms]?)$`)
+}
+
+type duration int
+
+func (d duration) String() string {
+	i := (int)(d)
+
+	f := 60 * 60 * 24 * 365
+	if i >= f {
+		if i%f == 0 {
+			return fmt.Sprintf("%dy", (int)(i/f))
+		}
+		return fmt.Sprintf("%0.2fy", (float32)(i/f))
+	}
+
+	f = 60 * 60 * 24
+	if i >= f {
+		if i%f == 0 {
+			return fmt.Sprintf("%dd", (int)(i/f))
+		}
+		return fmt.Sprintf("%0.2fd", (float32)(i/f))
+	}
+
+	f = 60 * 60
+	if i >= f {
+		if i%f == 0 {
+			return fmt.Sprintf("%dh", (int)(i/f))
+		}
+		return fmt.Sprintf("%0.2fh", (float32)(i/f))
+	}
+
+	f = 60
+	if i >= f && i%f == 0 {
+		return fmt.Sprintf("%dm", (int)(i/f))
+	}
+
+	return fmt.Sprintf("%ds", i)
+}
+
+func (d duration) parse(raw string) (int, error) {
+	m := durationPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return 0, fmt.Errorf("invalid duration '%s' (expecting something like '90d')")
+	}
+
+	f, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration '%s' (%s)", raw, err)
+	}
+
+	switch m[2] {
+	case "", "s", "S":
+		return (int)(f), nil
+
+	case "m", "M":
+		return (int)(f * 60), nil
+
+	case "h", "H":
+		return (int)(f * 60 * 60), nil
+
+	case "d", "D":
+		return (int)(f * 60 * 60 * 24), nil
+
+	case "w", "W":
+		return (int)(f * 60 * 60 * 24 * 7), nil
+
+	case "y", "Y":
+		return (int)(f * 60 * 60 * 24 * 365), nil
+	}
+
+	return 0, fmt.Errorf("unrecognized duration unit '%s' (in '%s')", m[2], raw)
+}
+
+func (d *duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw string
+
+	err := unmarshal(&raw)
+	if err != nil {
+		return err
+	}
+
+	d.UnmarshalEnv(raw)
+	return nil
+}
+
+func (d *duration) UnmarshalEnv(raw string) {
+	i, err := d.parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	*d = (duration)(i)
+}

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -919,3 +919,11 @@ func (db *DB) archiveShouldExist(uuid string) error {
 	}
 	return nil
 }
+
+func (db *DB) TruncateTaskLogs(age int) error {
+	return db.Exec(`
+       UPDATE tasks SET log = "(log truncated)"
+                  WHERE stopped_at IS NOT NULL
+                    AND stopped_at < ?`,
+		(int)(time.Now().Unix())-age)
+}

--- a/db/utils_test.go
+++ b/db/utils_test.go
@@ -1,0 +1,31 @@
+package db
+
+type q struct {
+	query string
+	args  []interface{}
+}
+
+func database(queries ...q) (*DB, error) {
+	db, err := Connect(":memory:")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := db.Setup(0); err != nil {
+		db.Disconnect()
+		return nil, err
+	}
+
+	for _, q := range queries {
+		if err := db.Exec(q.query, q.args...); err != nil {
+			db.Disconnect()
+			return nil, err
+		}
+	}
+
+	return db, nil
+}
+
+func SQL(query string, args ...interface{}) q {
+	return q{query: query, args: args}
+}

--- a/vendor/github.com/jhunt/go-envirotron/LICENSE
+++ b/vendor/github.com/jhunt/go-envirotron/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 James Hunt
+Copyright (c) 2019 James Hunt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/vendor/github.com/jhunt/go-envirotron/README.md
+++ b/vendor/github.com/jhunt/go-envirotron/README.md
@@ -1,6 +1,8 @@
 Envirotron
 ==========
 
+![Travis CI](https://travis-ci.org/jhunt/go-envirotron.svg?branch=master)
+
 Ever wanted to easily allow users to override configuration values
 in a Go program via environment variables, but didn't want to deal
 with the tedium of checking that variables are set, and the

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,8 +233,10 @@
 			"revision": "d74b1b6905297834d014b95038b9a58539832140"
 		},
 		{
+			"checksumSHA1": "rNZJS9wunHHoTjHd9oFqBrFCtz0=",
 			"path": "github.com/jhunt/go-envirotron",
-			"revision": "6bdf7cebaa407f9ef7869eeb673a268d04126c90"
+			"revision": "c8f2a184ad0f6023b23eafba1d0aaa382a357a6b",
+			"revisionTime": "2019-10-07T15:50:51Z"
 		},
 		{
 			"checksumSHA1": "0zh8BzWlmxf6Sh76Qn3b+maOOKg=",


### PR DESCRIPTION
This change introduces new retention lifetimes for purged archives
(which have already been removed from the underlying cloud storage)
and task log contents.

Fixes #589 