### PR TITLE
Daily Storage Increase can use larger units

### DIFF
--- a/web/htdocs/js/lib.js
+++ b/web/htdocs/js/lib.js
@@ -730,12 +730,18 @@
 
    ***************************************************/
   exported.bytes = function (x) { // {{{
+  	var sign = "";
+  	if (x < 0) {
+  		x = -x;
+			sign = "-";
+  	}
+
     var units = ["b", "K", "M", "G", "T"];
     while (units.length > 1 && x >= 1024) {
       units.shift();
       x /= 1024;
     }
-    return (Math.round(x * 10) / 10).toString() + units[0];
+    return sign + (Math.round(x * 10) / 10).toString() + units[0];
   };
 
   /***************************************************

--- a/web/htdocs/js/lib.js
+++ b/web/htdocs/js/lib.js
@@ -730,11 +730,11 @@
 
    ***************************************************/
   exported.bytes = function (x) { // {{{
-  	var sign = "";
-  	if (x < 0) {
-  		x = -x;
-			sign = "-";
-  	}
+    var sign = "";
+    if (x < 0) {
+      x = -x;
+      sign = "-";
+    }
 
     var units = ["b", "K", "M", "G", "T"];
     while (units.length > 1 && x >= 1024) {


### PR DESCRIPTION
Previously, if the daily storage increase in the web UI was negative,
then it would always display the amount in bytes, no matter how large
the number becomes. This should allow the unit formatting to work even
when the number is negative.