### PR TITLE
Reverse Global Tenant check logic in cancel task endpoint

### DIFF
--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -634,7 +634,7 @@ func (c *Core) v2API() *route.Router {
 			r.Fail(route.Oops(err, "Unable to retrieve task information"))
 			return
 		}
-		if task == nil || task.TenantUUID != db.GlobalTenantUUID {
+		if task == nil || task.TenantUUID == db.GlobalTenantUUID {
 			r.Fail(route.NotFound(err, "No such task"))
 			return
 		}


### PR DESCRIPTION
Attempting to cancel a task by DELETEing at the tenant specific task API
endpoint would result in No Such Task being returned. It appears that
this is because of a reversed logic check, which prevents this endpoint
from being a workaround to delete global tasks. Instead, it ONLY allows
the cancellation of global tasks.

Addresses #647