### PR TITLE
Make AEGIS.agent return the requested agent

### DIFF
--- a/web/htdocs/js/data.js
+++ b/web/htdocs/js/data.js
@@ -249,8 +249,8 @@
       return agents;
     },
     agent: function (uuid) {
-      for (var uuid in this.data.agent || {}) {
-        var agent = this.data.agent[uuid];
+      for (var u in this.data.agent || {}) {
+        var agent = this.data.agent[u];
         if (!agent.hidden && (agent.uuid == uuid || agent.address == uuid)) {
           return agent;
         }


### PR DESCRIPTION
Previously, it just returns the first agent in the hash. 

Fixes #660 