### PR TITLE
Fix Database Inconsistencies for jobs_new table

### DIFF
--- a/db/jobs.go
+++ b/db/jobs.go
@@ -367,6 +367,16 @@ func (db *DB) DeleteJob(id string) (bool, error) {
 	}
 
 	db.sendDeleteObjectEvent(job, "tenant:"+job.TenantUUID)
+
+	jobs, err := db.GetAllJobs(&JobFilter{ForTarget: job.TargetUUID})
+	if err != nil {
+		return false, nil
+	}
+	// if target has no jobs, it the target should be healthy
+	if len(jobs) == 0 {
+		db.UpdateTargetHealth(job.TargetUUID, true)
+	}
+
 	return true, nil
 }
 

--- a/db/schema.go
+++ b/db/schema.go
@@ -20,6 +20,7 @@ var Schemas = map[int]Schema{
 	9:  v9Schema{},
 	10: v10Schema{},
 	11: v11Schema{},
+	12: v12Schema{},
 }
 
 type Schema interface {

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Database Schema", func() {
 
 				var v int
 				Ω(r.Scan(&v)).Should(Succeed())
-				Ω(v).Should(Equal(11))
+				Ω(v).Should(Equal(12))
 			})
 
 			It("creates the correct tables", func() {

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -7,31 +7,31 @@ func (s v11Schema) Deploy(db *DB) error {
 
 	// set the tenant_uuid column to NOT NULL
 	err = db.Exec(`CREATE TABLE jobs_new (
-	               uuid               UUID PRIMARY KEY,
-	               target_uuid        UUID NOT NULL,
-	               store_uuid         UUID NOT NULL,
-	               tenant_uuid        UUID NOT NULL,
-	               name               TEXT NOT NULL,
-	               summary            TEXT NOT NULL,
-	               schedule           TEXT NOT NULL,
-	               keep_n             INTEGER NOT NULL DEFAULT 0,
-	               keep_days          INTEGER NOT NULL DEFAULT 0,
-	               next_run           INTEGER DEFAULT 0,
-	               priority           INTEGER DEFAULT 50,
-	               paused             BOOLEAN NOT NULL DEFAULT 0,
-	               fixed_key          INTEGER DEFAULT 0,
-	               healthy            BOOLEAN NOT NULL DEFAULT 0
-	             )`)
+			        uuid               UUID PRIMARY KEY,
+					target_uuid        UUID NOT NULL,
+					store_uuid         UUID NOT NULL,
+					tenant_uuid        UUID NOT NULL,
+					name               TEXT NOT NULL,
+					summary            TEXT NOT NULL,
+					schedule           TEXT NOT NULL,
+					keep_n             INTEGER NOT NULL DEFAULT 0,
+					keep_days          INTEGER NOT NULL DEFAULT 0,
+					next_run           INTEGER DEFAULT 0,
+					priority           INTEGER DEFAULT 50,
+					paused             BOOLEAN NOT NULL DEFAULT 0,
+					fixed_key          INTEGER DEFAULT 0,
+					healthy            BOOLEAN NOT NULL DEFAULT 0
+	            )`)
 	if err != nil {
 		return err
 	}
 	err = db.Exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
-	                                     name, summary, schedule, keep_n, keep_days,
-	                                     next_run, priority, paused, fixed_key, healthy)
-	                              SELECT j.uuid, j.target_uuid, j.store_uuid, j.tenant_uuid,
-	                                     j.name, j.summary, j.schedule, j.keep_n, j.keep_days,
-	                                     j.next_run, j.priority, IFNULL(j.paused, 0), j.fixed_key, IFNULL(j.healthy, 0)
-	                                FROM jobs j`)
+                            name, summary, schedule, keep_n, keep_days,
+                            next_run, priority, paused, fixed_key, healthy)
+                    SELECT j.uuid, j.target_uuid, j.store_uuid, j.tenant_uuid,
+                            j.name, j.summary, j.schedule, j.keep_n, j.keep_days,
+                            j.next_run, j.priority, IFNULL(j.paused, 0), j.fixed_key, 0
+                        FROM jobs j`)
 	if err != nil {
 		return err
 	}
@@ -42,6 +42,56 @@ func (s v11Schema) Deploy(db *DB) error {
 	err = db.Exec(`ALTER TABLE jobs_new RENAME TO jobs`)
 	if err != nil {
 		return err
+	}
+
+	jobs, err := db.GetAllJobs(&JobFilter{})
+	if err != nil {
+		return nil
+	}
+	for _, job := range jobs {
+		healthy := job.LastTaskStatus == "done"
+		db.UpdateJobHealth(job.UUID, healthy)
+	}
+
+	err = db.Exec(`CREATE TABLE targets_new (
+                    uuid               UUID PRIMARY KEY,
+                    tenant_uuid        UUID NOT NULL,
+                    name               TEXT NOT NULL,
+                    summary            TEXT NOT NULL,
+                    plugin             TEXT NOT NULL,
+                    endpoint           TEXT NOT NULL,
+                    agent              TEXT NOT NULL,
+                    compression        TEXT NOT NULL DEFAULT 'none',
+                    healthy            BOOLEAN NOT NULL DEFAULT 0
+                )`)
+	if err != nil {
+		return err
+	}
+
+	err = db.Exec(`INSERT INTO targets_new (uuid, tenant_uuid, name summary,
+                                            plugin, endpoint, agent, compression,
+                                            healthy)
+                        SELECT t.uuid, t.tenant_uuid, t.name, t.summary,
+                                    t.plugin, t.endpoing, t.agent, t.compression,
+                                    0
+                            FROM targets t)`)
+
+	targets, err := db.GetAllTargets(&TargetFilter{})
+	if err != nil {
+		return nil
+	}
+	for _, target := range targets {
+		jobs, err = db.GetAllJobs(&JobFilter{ForTarget: target.UUID})
+		if err != nil {
+			return nil
+		}
+		healthy := true
+		for _, job := range jobs {
+			if !job.Healthy {
+				healthy = false
+			}
+		}
+		db.UpdateTargetHealth(target.UUID, healthy)
 	}
 
 	err = db.Exec(`UPDATE schema_info set version = 11`)

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -68,13 +68,24 @@ func (s v11Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`INSERT INTO targets_new (uuid, tenant_uuid, name summary,
+	err = db.Exec(`INSERT INTO targets_new (uuid, tenant_uuid, name, summary,
                                             plugin, endpoint, agent, compression,
                                             healthy)
                         SELECT t.uuid, t.tenant_uuid, t.name, t.summary,
-                                    t.plugin, t.endpoing, t.agent, t.compression,
+                                    t.plugin, t.endpoint, t.agent, t.compression,
                                     0
-                            FROM targets t)`)
+                            FROM targets t`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`DROP TABLE targets`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`ALTER TABLE targets_new RENAME TO targets`)
+	if err != nil {
+		return err
+	}
 
 	targets, err := db.GetAllTargets(&TargetFilter{})
 	if err != nil {

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -44,67 +44,6 @@ func (s v11Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	jobs, err := db.GetAllJobs(&JobFilter{})
-	if err != nil {
-		return nil
-	}
-	for _, job := range jobs {
-		healthy := job.LastTaskStatus == "done"
-		db.UpdateJobHealth(job.UUID, healthy)
-	}
-
-	err = db.Exec(`CREATE TABLE targets_new (
-                    uuid               UUID PRIMARY KEY,
-                    tenant_uuid        UUID NOT NULL,
-                    name               TEXT NOT NULL,
-                    summary            TEXT NOT NULL,
-                    plugin             TEXT NOT NULL,
-                    endpoint           TEXT NOT NULL,
-                    agent              TEXT NOT NULL,
-                    compression        TEXT NOT NULL DEFAULT 'none',
-                    healthy            BOOLEAN NOT NULL DEFAULT 0
-                )`)
-	if err != nil {
-		return err
-	}
-
-	err = db.Exec(`INSERT INTO targets_new (uuid, tenant_uuid, name, summary,
-                                            plugin, endpoint, agent, compression,
-                                            healthy)
-                        SELECT t.uuid, t.tenant_uuid, t.name, t.summary,
-                                    t.plugin, t.endpoint, t.agent, t.compression,
-                                    0
-                            FROM targets t`)
-	if err != nil {
-		return err
-	}
-	err = db.Exec(`DROP TABLE targets`)
-	if err != nil {
-		return err
-	}
-	err = db.Exec(`ALTER TABLE targets_new RENAME TO targets`)
-	if err != nil {
-		return err
-	}
-
-	targets, err := db.GetAllTargets(&TargetFilter{})
-	if err != nil {
-		return nil
-	}
-	for _, target := range targets {
-		jobs, err = db.GetAllJobs(&JobFilter{ForTarget: target.UUID})
-		if err != nil {
-			return nil
-		}
-		healthy := true
-		for _, job := range jobs {
-			if !job.Healthy {
-				healthy = false
-			}
-		}
-		db.UpdateTargetHealth(target.UUID, healthy)
-	}
-
 	err = db.Exec(`UPDATE schema_info set version = 11`)
 	if err != nil {
 		return err

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -7,21 +7,21 @@ func (s v11Schema) Deploy(db *DB) error {
 
 	// set the tenant_uuid column to NOT NULL
 	err = db.Exec(`CREATE TABLE jobs_new (
-			        uuid               UUID PRIMARY KEY,
-					target_uuid        UUID NOT NULL,
-					store_uuid         UUID NOT NULL,
-					tenant_uuid        UUID NOT NULL,
-					name               TEXT NOT NULL,
-					summary            TEXT NOT NULL,
-					schedule           TEXT NOT NULL,
-					keep_n             INTEGER NOT NULL DEFAULT 0,
-					keep_days          INTEGER NOT NULL DEFAULT 0,
-					next_run           INTEGER DEFAULT 0,
-					priority           INTEGER DEFAULT 50,
-					paused             BOOLEAN NOT NULL DEFAULT 0,
-					fixed_key          INTEGER DEFAULT 0,
-					healthy            BOOLEAN NOT NULL DEFAULT 0
-	            )`)
+                    uuid               UUID PRIMARY KEY,
+                    target_uuid        UUID NOT NULL,
+                    store_uuid         UUID NOT NULL,
+                    tenant_uuid        UUID NOT NULL,
+                    name               TEXT NOT NULL,
+                    summary            TEXT NOT NULL,
+                    schedule           TEXT NOT NULL,
+                    keep_n             INTEGER NOT NULL DEFAULT 0,
+                    keep_days          INTEGER NOT NULL DEFAULT 0,
+                    next_run           INTEGER DEFAULT 0,
+                    priority           INTEGER DEFAULT 50,
+                    paused             BOOLEAN NOT NULL DEFAULT 0,
+                    fixed_key          INTEGER DEFAULT 0,
+                    healthy            BOOLEAN NOT NULL DEFAULT 0
+                )`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -44,6 +44,15 @@ func (s v11Schema) Deploy(db *DB) error {
 		return err
 	}
 
+	jobs, err := db.GetAllJobs(&JobFilter{})
+	if err != nil {
+		return nil
+	}
+	for _, job := range jobs {
+		healthy := job.LastTaskStatus == "done"
+		db.UpdateJobHealth(job.UUID, healthy)
+	}
+
 	err = db.Exec(`UPDATE schema_info set version = 11`)
 	if err != nil {
 		return err

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -44,15 +44,6 @@ func (s v11Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	jobs, err := db.GetAllJobs(&JobFilter{})
-	if err != nil {
-		return nil
-	}
-	for _, job := range jobs {
-		healthy := job.LastTaskStatus == "done"
-		db.UpdateJobHealth(job.UUID, healthy)
-	}
-
 	err = db.Exec(`UPDATE schema_info set version = 11`)
 	if err != nil {
 		return err

--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -5,6 +5,12 @@ type v11Schema struct{}
 func (s v11Schema) Deploy(db *DB) error {
 	var err error
 
+	//drop the jobs_new table if it exists
+	err = db.Exec(`DROP TABLE IF EXISTS jobs_new`)
+	if err != nil {
+		return err
+	}
+
 	// set the tenant_uuid column to NOT NULL
 	err = db.Exec(`CREATE TABLE jobs_new (
                     uuid               UUID PRIMARY KEY,

--- a/db/schema_v12.go
+++ b/db/schema_v12.go
@@ -1,7 +1,5 @@
 package db
 
-import "fmt"
-
 type v12Schema struct{}
 
 func (s v12Schema) Deploy(db *DB) error {
@@ -15,8 +13,7 @@ func (s v12Schema) Deploy(db *DB) error {
 		healthy := job.LastTaskStatus == "done"
 		db.UpdateJobHealth(job.UUID, healthy)
 	}
-	tenant := RandomID()
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE targets_new (
+	err = db.Exec(`CREATE TABLE targets_new (
                     uuid               UUID PRIMARY KEY,
                     tenant_uuid        UUID NOT NULL DEFAULT '%s',
                     name               TEXT NOT NULL,
@@ -26,7 +23,7 @@ func (s v12Schema) Deploy(db *DB) error {
                     agent              TEXT NOT NULL,
                     compression        TEXT NOT NULL DEFAULT 'none',
                     healthy            BOOLEAN NOT NULL DEFAULT 0
-                )`, tenant))
+                )`)
 	if err != nil {
 		return err
 	}

--- a/db/schema_v12.go
+++ b/db/schema_v12.go
@@ -1,0 +1,114 @@
+package db
+
+type v12Schema struct{}
+
+func (s v12Schema) Deploy(db *DB) error {
+	var err error
+
+	// set the tenant_uuid column to NOT NULL
+	err = db.Exec(`CREATE TABLE jobs_new (
+                    uuid               UUID PRIMARY KEY,
+                    target_uuid        UUID NOT NULL,
+                    store_uuid         UUID NOT NULL,
+                    tenant_uuid        UUID NOT NULL,
+                    name               TEXT NOT NULL,
+                    summary            TEXT NOT NULL,
+                    schedule           TEXT NOT NULL,
+                    keep_n             INTEGER NOT NULL DEFAULT 0,
+                    keep_days          INTEGER NOT NULL DEFAULT 0,
+                    next_run           INTEGER DEFAULT 0,
+                    priority           INTEGER DEFAULT 50,
+                    paused             BOOLEAN NOT NULL DEFAULT 0,
+                    fixed_key          INTEGER DEFAULT 0,
+                    healthy            BOOLEAN NOT NULL DEFAULT 0
+                )`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
+                            name, summary, schedule, keep_n, keep_days,
+                            next_run, priority, paused, fixed_key, healthy)
+                    SELECT j.uuid, j.target_uuid, j.store_uuid, j.tenant_uuid,
+                            j.name, j.summary, j.schedule, j.keep_n, j.keep_days,
+                            j.next_run, j.priority, IFNULL(j.paused, 0), j.fixed_key, 0
+                        FROM jobs j`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`DROP TABLE jobs`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`ALTER TABLE jobs_new RENAME TO jobs`)
+	if err != nil {
+		return err
+	}
+
+	jobs, err := db.GetAllJobs(&JobFilter{})
+	if err != nil {
+		return nil
+	}
+	for _, job := range jobs {
+		healthy := job.LastTaskStatus == "done"
+		db.UpdateJobHealth(job.UUID, healthy)
+	}
+
+	err = db.Exec(`CREATE TABLE targets_new (
+                    uuid               UUID PRIMARY KEY,
+                    tenant_uuid        UUID NOT NULL,
+                    name               TEXT NOT NULL,
+                    summary            TEXT NOT NULL,
+                    plugin             TEXT NOT NULL,
+                    endpoint           TEXT NOT NULL,
+                    agent              TEXT NOT NULL,
+                    compression        TEXT NOT NULL DEFAULT 'none',
+                    healthy            BOOLEAN NOT NULL DEFAULT 0
+                )`)
+	if err != nil {
+		return err
+	}
+
+	err = db.Exec(`INSERT INTO targets_new (uuid, tenant_uuid, name, summary,
+                                            plugin, endpoint, agent, compression,
+                                            healthy)
+                        SELECT t.uuid, t.tenant_uuid, t.name, t.summary,
+                                    t.plugin, t.endpoint, t.agent, t.compression,
+                                    0
+                            FROM targets t`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`DROP TABLE targets`)
+	if err != nil {
+		return err
+	}
+	err = db.Exec(`ALTER TABLE targets_new RENAME TO targets`)
+	if err != nil {
+		return err
+	}
+
+	targets, err := db.GetAllTargets(&TargetFilter{})
+	if err != nil {
+		return nil
+	}
+	for _, target := range targets {
+		jobs, err = db.GetAllJobs(&JobFilter{ForTarget: target.UUID})
+		if err != nil {
+			return nil
+		}
+		healthy := true
+		for _, job := range jobs {
+			if !job.Healthy {
+				healthy = false
+			}
+		}
+		db.UpdateTargetHealth(target.UUID, healthy)
+	}
+
+	err = db.Exec(`UPDATE schema_info set version = 12`)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/db/schema_v12.go
+++ b/db/schema_v12.go
@@ -7,45 +7,6 @@ type v12Schema struct{}
 func (s v12Schema) Deploy(db *DB) error {
 	var err error
 
-	// set the tenant_uuid column to NOT NULL
-	err = db.Exec(`CREATE TABLE jobs_new (
-                    uuid               UUID PRIMARY KEY,
-                    target_uuid        UUID NOT NULL,
-                    store_uuid         UUID NOT NULL,
-                    tenant_uuid        UUID NOT NULL,
-                    name               TEXT NOT NULL,
-                    summary            TEXT NOT NULL,
-                    schedule           TEXT NOT NULL,
-                    keep_n             INTEGER NOT NULL DEFAULT 0,
-                    keep_days          INTEGER NOT NULL DEFAULT 0,
-                    next_run           INTEGER DEFAULT 0,
-                    priority           INTEGER DEFAULT 50,
-                    paused             BOOLEAN NOT NULL DEFAULT 0,
-                    fixed_key          INTEGER DEFAULT 0,
-                    healthy            BOOLEAN NOT NULL DEFAULT 0
-                )`)
-	if err != nil {
-		return err
-	}
-	err = db.Exec(`INSERT INTO jobs_new (uuid, target_uuid, store_uuid, tenant_uuid,
-                            name, summary, schedule, keep_n, keep_days,
-                            next_run, priority, paused, fixed_key, healthy)
-                    SELECT j.uuid, j.target_uuid, j.store_uuid, j.tenant_uuid,
-                            j.name, j.summary, j.schedule, j.keep_n, j.keep_days,
-                            j.next_run, j.priority, IFNULL(j.paused, 0), j.fixed_key, 0
-                        FROM jobs j`)
-	if err != nil {
-		return err
-	}
-	err = db.Exec(`DROP TABLE jobs`)
-	if err != nil {
-		return err
-	}
-	err = db.Exec(`ALTER TABLE jobs_new RENAME TO jobs`)
-	if err != nil {
-		return err
-	}
-
 	jobs, err := db.GetAllJobs(&JobFilter{})
 	if err != nil {
 		return nil

--- a/db/schema_v12.go
+++ b/db/schema_v12.go
@@ -1,5 +1,7 @@
 package db
 
+import "fmt"
+
 type v12Schema struct{}
 
 func (s v12Schema) Deploy(db *DB) error {
@@ -52,10 +54,10 @@ func (s v12Schema) Deploy(db *DB) error {
 		healthy := job.LastTaskStatus == "done"
 		db.UpdateJobHealth(job.UUID, healthy)
 	}
-
-	err = db.Exec(`CREATE TABLE targets_new (
+	tenant := RandomID()
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE targets_new (
                     uuid               UUID PRIMARY KEY,
-                    tenant_uuid        UUID NOT NULL DEFAULT '',
+                    tenant_uuid        UUID NOT NULL DEFAULT '%s',
                     name               TEXT NOT NULL,
                     summary            TEXT NOT NULL DEFAULT '',
                     plugin             TEXT NOT NULL,
@@ -63,7 +65,7 @@ func (s v12Schema) Deploy(db *DB) error {
                     agent              TEXT NOT NULL,
                     compression        TEXT NOT NULL DEFAULT 'none',
                     healthy            BOOLEAN NOT NULL DEFAULT 0
-                )`)
+                )`, tenant))
 	if err != nil {
 		return err
 	}

--- a/db/schema_v12.go
+++ b/db/schema_v12.go
@@ -55,9 +55,9 @@ func (s v12Schema) Deploy(db *DB) error {
 
 	err = db.Exec(`CREATE TABLE targets_new (
                     uuid               UUID PRIMARY KEY,
-                    tenant_uuid        UUID NOT NULL,
+                    tenant_uuid        UUID NOT NULL DEFAULT '',
                     name               TEXT NOT NULL,
-                    summary            TEXT NOT NULL,
+                    summary            TEXT NOT NULL DEFAULT '',
                     plugin             TEXT NOT NULL,
                     endpoint           TEXT NOT NULL,
                     agent              TEXT NOT NULL,
@@ -67,7 +67,6 @@ func (s v12Schema) Deploy(db *DB) error {
 	if err != nil {
 		return err
 	}
-
 	err = db.Exec(`INSERT INTO targets_new (uuid, tenant_uuid, name, summary,
                                             plugin, endpoint, agent, compression,
                                             healthy)


### PR DESCRIPTION
When upgrading from 8.5.0 -> 8.6.0 failed it left the jobs_new table in the database. This patch checks if the jobs_new table exists and if it already exists drops the table and the rest of the migrating to schema_v11 continues.