### PR TITLE
Fixed jobs_new table already exists when upgrading to v_11

### DIFF
--- a/db/schema_v11.go
+++ b/db/schema_v11.go
@@ -5,6 +5,12 @@ type v11Schema struct{}
 func (s v11Schema) Deploy(db *DB) error {
 	var err error
 
+	//drop the jobs_new table if it exists
+	err = db.Exec(`DROP TABLE IF EXISTS jobs_new`)
+	if err != nil {
+		return err
+	}
+
 	// set the tenant_uuid column to NOT NULL
 	err = db.Exec(`CREATE TABLE jobs_new (
                     uuid               UUID PRIMARY KEY,


### PR DESCRIPTION
When upgrading from 8.5.0 -> 8.6.0 failed it left the jobs_new table in the database. This patch checks if the jobs_new table exists and if it already exists drops the table and the rest of the migrating to schema_v11 continues.