### PR TITLE
Report errors better in v12 migration.

### DIFF
--- a/db/jobs.go
+++ b/db/jobs.go
@@ -333,14 +333,16 @@ func (db *DB) UpdateJob(job *Job) error {
 func (db *DB) UpdateJobHealth(id string, status bool) error {
 	job, err := db.GetJob(id)
 	if err != nil {
-		return fmt.Errorf("unable to find job %s to update health: %s", id, err)
+		return fmt.Errorf("Error when finding job with uuid `%s' to update health: %s", id, err)
 	}
-	job.Healthy = status
+	if job == nil {
+		return fmt.Errorf("No job with uuid `%s' was found to update health")
+	}
 	err = db.Exec(`
         UPDATE jobs
             SET healthy = ?
         WHERE uuid = ?`,
-		job.Healthy,
+		status,
 		job.UUID)
 	if err != nil {
 		return err

--- a/db/schema_v12.go
+++ b/db/schema_v12.go
@@ -7,11 +7,14 @@ func (s v12Schema) Deploy(db *DB) error {
 
 	jobs, err := db.GetAllJobs(&JobFilter{})
 	if err != nil {
-		return nil
+		return err
 	}
 	for _, job := range jobs {
 		healthy := job.LastTaskStatus == "done"
-		db.UpdateJobHealth(job.UUID, healthy)
+		err = db.UpdateJobHealth(job.UUID, healthy)
+		if err != nil {
+			return err
+		}
 	}
 	err = db.Exec(`CREATE TABLE targets_new (
                     uuid               UUID PRIMARY KEY,

--- a/db/targets.go
+++ b/db/targets.go
@@ -271,14 +271,16 @@ func (db *DB) UpdateTarget(target *Target) error {
 func (db *DB) UpdateTargetHealth(id string, health bool) error {
 	target, err := db.GetTarget(id)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error when finding target with uuid `%s' to update health: %s", id, err)
 	}
-	target.Healthy = health
+	if target == nil {
+		return fmt.Errorf("No target with uuid `%s' was found to update health")
+	}
 	err = db.Exec(`
         UPDATE targets
             SET healthy = ?
         WHERE uuid = ?`,
-		target.Healthy,
+		health,
 		target.UUID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Don't segfault if the job can't be found. Don't return no error if you
can't list jobs. Return consistent errors for setting job and target
health.