### PR TITLE
Storage footprint

### DIFF
--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -1923,7 +1923,8 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
               <h3>Storage Footprint</h3>
               [[ var n = 0, used = 0;
                  $.each(AEGIS.archives({ tenant: target.tenant_uuid,
-                                         system: target.uuid }),
+                                         system: target.uuid,
+                                         purged: false }),
                         function (i, archive) {
                           if (archive.status == "valid") {
                             n++;

--- a/web/htdocs/js/data.js
+++ b/web/htdocs/js/data.js
@@ -267,7 +267,8 @@
           var archive = this.data.archive[uuid];
           if (archive.tenant_uuid != q.tenant
            || ('system'  in q && archive.target_uuid  != q.system)
-           || ('store'   in q && archive.store_uuid   != q.store)) {
+           || ('store'   in q && archive.store_uuid   != q.store)
+           || ('purged'  in q && (archive.status == "purged") != q.purged)) {
             continue;
           }
           archives.push(archive);

--- a/web/htdocs/js/data.js
+++ b/web/htdocs/js/data.js
@@ -266,8 +266,8 @@
         for (var uuid in this.data.archive || {}) {
           var archive = this.data.archive[uuid];
           if (archive.tenant_uuid != q.tenant
-           || ('system'  in q && archive.target_uuid  != q.system)
-           || ('store'   in q && archive.store_uuid   != q.store)
+           || ('system'  in q && archive.target_uuid          != q.system)
+           || ('store'   in q && archive.store_uuid           != q.store)
            || ('purged'  in q && (archive.status == "purged") != q.purged)) {
             continue;
           }

--- a/web/test/tests.js
+++ b/web/test/tests.js
@@ -327,14 +327,14 @@ QUnit.module('AEGIS Object Queries');
         tenant_uuid: 'the-system-tenant',
         target_uuid: 'the-shield-target',
         store_uuid:  'the-system-s3-store',
-        status:      'valid'
+        status:      'invalid'
       })
       .insert('archive', {
         uuid: 'shield-backup-archive-3',
         tenant_uuid: 'the-system-tenant',
         target_uuid: 'the-shield-target',
         store_uuid:  'the-global-store',
-        status:      'invalid'
+        status:      'purged'
       })
       .insert('archive', {
         uuid: 'ccdb-backup-archive-1',
@@ -348,7 +348,7 @@ QUnit.module('AEGIS Object Queries');
         tenant_uuid: 'the-acme-tenant',
         target_uuid: 'the-uaadb-target',
         store_uuid:  'the-global-store',
-        status:      'purged'
+        status:      'valid'
       })
     ;
   };
@@ -542,17 +542,18 @@ QUnit.module('AEGIS Object Queries');
         { uuid: 'shield-backup-archive-2' } ],
       'the-system-tenant has two archives for the-shield-target in the-system-s3-store');
 
-    /* by purged-ness */
-    is.set(db.archives({ purged: true }),
-      [ { uuid:   'shield-backup-archive-4' },
-        { uuid:   'shield-backup-archive-5' } ],
-      'asking only for purged archives correctly retrieves only purged archives');
-
-    is.set(db.archives({ purged: false }),
+    /* by tenant + purged-less-ness */
+    is.set(db.archives({ tenant: 'the-system-tenant',
+                         purged: false }),
       [ { uuid:   'shield-backup-archive-1' },
-        { uuid:   'shield-backup-archive-2' },
-        { uuid:   'shield-backup-archive-3' } ],
-      'asking only for unpurged archives correctly retrieves only valid and invalid archives');
+        { uuid:   'shield-backup-archive-2' } ],
+      'asking only for non-purged archives correctly retrieves valid and invalid archives, but not purged');
+
+    /* by tenant + purged-ness */
+    is.set(db.archives({ tenant: 'the-acme-tenant',
+                         purged: true }),
+      [ { uuid: "ccdb-backup-archive-1" } ],
+      'asking only for purged archives correctly retrieves only purged archives');
 
     /* single archive retrieval */
     is.contained(

--- a/web/test/tests.js
+++ b/web/test/tests.js
@@ -319,31 +319,36 @@ QUnit.module('AEGIS Object Queries');
         uuid: 'shield-backup-archive-1',
         tenant_uuid: 'the-system-tenant',
         target_uuid: 'the-shield-target',
-        store_uuid:  'the-system-s3-store'
+        store_uuid:  'the-system-s3-store',
+        status:      'valid'
       })
       .insert('archive', {
         uuid: 'shield-backup-archive-2',
         tenant_uuid: 'the-system-tenant',
         target_uuid: 'the-shield-target',
-        store_uuid:  'the-system-s3-store'
+        store_uuid:  'the-system-s3-store',
+        status:      'valid'
       })
       .insert('archive', {
         uuid: 'shield-backup-archive-3',
         tenant_uuid: 'the-system-tenant',
         target_uuid: 'the-shield-target',
-        store_uuid:  'the-global-store'
+        store_uuid:  'the-global-store',
+        status:      'invalid'
       })
       .insert('archive', {
         uuid: 'ccdb-backup-archive-1',
         tenant_uuid: 'the-acme-tenant',
         target_uuid: 'the-ccdb-target',
-        store_uuid:  'the-global-store'
+        store_uuid:  'the-global-store',
+        status:      'purged'
       })
       .insert('archive', {
         uuid: 'uaadb-backup-archive-1',
         tenant_uuid: 'the-acme-tenant',
         target_uuid: 'the-uaadb-target',
-        store_uuid:  'the-global-store'
+        store_uuid:  'the-global-store',
+        status:      'purged'
       })
     ;
   };
@@ -536,6 +541,18 @@ QUnit.module('AEGIS Object Queries');
       [ { uuid: 'shield-backup-archive-1' },
         { uuid: 'shield-backup-archive-2' } ],
       'the-system-tenant has two archives for the-shield-target in the-system-s3-store');
+
+    /* by purged-ness */
+    is.set(db.archives({ purged: true }),
+      [ { uuid:   'shield-backup-archive-4' },
+        { uuid:   'shield-backup-archive-5' } ],
+      'asking only for purged archives correctly retrieves only purged archives');
+
+    is.set(db.archives({ purged: false }),
+      [ { uuid:   'shield-backup-archive-1' },
+        { uuid:   'shield-backup-archive-2' },
+        { uuid:   'shield-backup-archive-3' } ],
+      'asking only for unpurged archives correctly retrieves only valid and invalid archives');
 
     /* single archive retrieval */
     is.contained(


### PR DESCRIPTION
The storage footprint on each data system page in the web ui was counting purged archives. This PR adds the ability to filter archive retrieval from AEGIS by purged-ness or purged-less-ness. The storage footprint template then uses this to only count archives that SHIELD is aware are still impacting the storage footprint.

The archive retrieval code has gained a few more test specs related to filtering by purged-ness.

Fixes #658