### PR TITLE
Adding Mac ARM64 functionality to shield

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch as build
+FROM golang:1.16-stretch as build
 
 RUN apt-get update \
  && apt-get install -y bzip2 unzip curl openssh-client
@@ -26,7 +26,7 @@ RUN mkdir -p /dist/bin /dist/plugins \
 ADD init /dist/init
 RUN chmod 0755 /dist/init/*
 
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 RUN apt-get update \
  && apt-get install -y bzip2 curl openssh-client \
  && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DOCKER_TAG   ?= dev
 EDGE         ?= edge
 
 # Everything; this is the default behavior
+LDFLAGS := -X main.Version=$(VERSION)
 all: build test
 build: format shieldd shield shield-agent shield-schema shield-crypt shield-report plugins
 
@@ -117,6 +118,7 @@ release:
 	@echo "Compiling SHIELD CLI For Linux and macOS..."
 	GOOS=linux  GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o artifacts/shield-linux-amd64  ./cmd/shield
 	GOOS=darwin GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o artifacts/shield-darwin-amd64 ./cmd/shield
+	GOOS=darwin GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o artifacts/shield-darwin-arm64 ./cmd/shield
 	mkdir -p "$(ARTIFACTS)/cli"
 	cp artifacts/shield-linux-amd64 "$(ARTIFACTS)/cli/shield"
 
@@ -125,7 +127,8 @@ release:
 	cd artifacts && for x in shield-server-*; do \
 	  cp -a ../web/htdocs $$x/webui; \
 	  mkdir -p $$x/webui/cli/linux; cp ../artifacts/shield-linux-amd64   $$x/webui/cli/linux/shield; \
-	  mkdir -p $$x/webui/cli/mac;   cp ../artifacts/shield-darwin-amd64  $$x/webui/cli/mac/shield; \
+	  mkdir -p $$x/webui/cli/mac-amd64;   cp ../artifacts/shield-darwin-amd64  $$x/webui/cli/mac-amd64/shield; \
+	  mkdir -p $$x/webui/cli/mac-arm64; cp ../artifacts/shield-darwin-arm64 $$x/webui/cli/mac-arm64/shield; \
 	  cp ../bin/shield-pipe      $$x/daemon; \
 	  cp ../bin/shield-recover   $$x/daemon; \
 	  cp ../bin/shield-restarter $$x/daemon; \

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ release:
 	cd artifacts && for x in shield-server-*; do \
 	  cp -a ../web/htdocs $$x/webui; \
 	  mkdir -p $$x/webui/cli/linux; cp ../artifacts/shield-linux-amd64   $$x/webui/cli/linux/shield; \
-	  mkdir -p $$x/webui/cli/mac-amd64;   cp ../artifacts/shield-darwin-amd64  $$x/webui/cli/mac-amd64/shield; \
-	  mkdir -p $$x/webui/cli/mac-arm64; cp ../artifacts/shield-darwin-arm64 $$x/webui/cli/mac-arm64/shield; \
+	  mkdir -p $$x/webui/cli/darwin/amd64;   cp ../artifacts/shield-darwin-amd64  $$x/webui/cli/darwin/amd64/shield; \
+	  mkdir -p $$x/webui/cli/darwin/arm64; cp ../artifacts/shield-darwin-arm64 $$x/webui/cli/darwin/arm64/shield; \
 	  cp ../bin/shield-pipe      $$x/daemon; \
 	  cp ../bin/shield-recover   $$x/daemon; \
 	  cp ../bin/shield-restarter $$x/daemon; \

--- a/plugin/gspt.go
+++ b/plugin/gspt.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package plugin

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -9,7 +9,8 @@
   </head>
   <body>
     <div class="top-bar">
-      <a class="cli" href="/cli/mac/shield"   title="Download MacOS SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+      <a class="cli" href="/cli/mac-amd64/shield"   title="Download MacOS (Intel) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+      <a class="cli" href="cli/mac-arm64/shield" title="Download MacOS (M1) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
       <a class="cli" href="/cli/linux/shield" title="Download Linux SHIELD CLI"><i class="fab fa-1x fa-linux"></i></a>
       <h1>SHIELD</h1></div>
     <div id="side-bar"></div>
@@ -550,7 +551,8 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
         Renders the top-most bar, with the SHIELD name / environment, and the
         current users name / tenant and "personal settings" menu.
       ]]
-        <a class="cli" href="/cli/mac/shield"   title="Download MacOS SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+        <a class="cli" href="/cli/mac-amd64/shield"   title="Download MacOS (Intel) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+        <a class="cli" href="cli/mac-arm64/shield" title="Download MacOS (M1) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
         <a class="cli" href="/cli/linux/shield" title="Download Linux SHIELD CLI"><i class="fab fa-1x fa-linux"></i></a>
         <h1><a href="#!/systems">SHIELD [[ if (AEGIS.shield.color) { ]]<span style="color:[[= AEGIS.shield.color ]]">[[ } ]][[= h(AEGIS.shield.env) ]]</span></a></h1>
         [[ if (AEGIS.authenticated()) { ]]

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -9,8 +9,8 @@
   </head>
   <body>
     <div class="top-bar">
-      <a class="cli" href="/cli/mac-amd64/shield"   title="Download MacOS (Intel) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
-      <a class="cli" href="cli/mac-arm64/shield" title="Download MacOS (M1) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+      <a class="cli" href="/cli/darwin/amd64/shield"   title="Download MacOS (Intel) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+      <a class="cli" href="/cli/darwin/arm64/shield" title="Download MacOS (M1) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
       <a class="cli" href="/cli/linux/shield" title="Download Linux SHIELD CLI"><i class="fab fa-1x fa-linux"></i></a>
       <h1>SHIELD</h1></div>
     <div id="side-bar"></div>
@@ -551,8 +551,8 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
         Renders the top-most bar, with the SHIELD name / environment, and the
         current users name / tenant and "personal settings" menu.
       ]]
-        <a class="cli" href="/cli/mac-amd64/shield"   title="Download MacOS (Intel) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
-        <a class="cli" href="cli/mac-arm64/shield" title="Download MacOS (M1) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+        <a class="cli" href="/cli/darwin/amd64/shield"   title="Download MacOS (Intel) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
+        <a class="cli" href="/cli/darwin/arm64/shield" title="Download MacOS (M1) SHIELD CLI"><i class="fab fa-1x fa-apple"></i></a>
         <a class="cli" href="/cli/linux/shield" title="Download Linux SHIELD CLI"><i class="fab fa-1x fa-linux"></i></a>
         <h1><a href="#!/systems">SHIELD [[ if (AEGIS.shield.color) { ]]<span style="color:[[= AEGIS.shield.color ]]">[[ } ]][[= h(AEGIS.shield.env) ]]</span></a></h1>
         [[ if (AEGIS.authenticated()) { ]]


### PR DESCRIPTION
This adds functionality to shield to build native arm64 binaries and updates the shield UI to point to both intel and arm64 binaries.