### PR TITLE
Added releases notes for the bug fix- Login screen in Github OAuth

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+Bug Fix
+=========
+- Fixed login screen for Github OAuth
+ 


### PR DESCRIPTION
Bug fix for the login screen of Shield not showing Github OAuth button. 