### PR TITLE
Adding --file flag for shield curl

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,4 +1,3 @@
-Bug Fix
+Improvements
 =========
-- Fixed login screen for Github OAuth
- 
+- Added `--file` flag to SHIELD's curl to use a filename to supply the request body.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+Bug Fix
+=========
+- Fixed login screen for Github OAuth
+ 

--- a/cmd/shield/help.go
+++ b/cmd/shield/help.go
@@ -584,9 +584,14 @@ func ShowHelp(command string) {
 
 	/* }}} */
 	case "curl": /* {{{ */
-		fmt.Printf("USAGE: @G{shield} curl [@Y{METHOD}] @Y{RELATIVE-URL} [@Y{BODY}]\n")
+		fmt.Printf("USAGE: @G{shield} curl [OPTIONS] [@Y{METHOD}] @Y{RELATIVE-URL} [@Y{BODY}]\n")
 		fmt.Printf("\n")
 		fmt.Printf("  Issues raw HTTP requests to the targeted SHIELD Core.\n")
+		fmt.Printf("\n")
+		fmt.Printf("@B{Options:}\n")
+		fmt.Printf("\n")
+		fmt.Printf("  --file      Use the contents of an input file to supply a request \n")
+		fmt.Printf("              body.\n")
 		fmt.Printf("\n")
 		fmt.Printf("  Any valid HTTP method can be provided, but shield will default to\n")
 		fmt.Printf("  using @M{GET}.  Some HTTP methods, like POST and PUT, may require\n")

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -49,7 +49,9 @@ var opts struct {
 		List bool `cli:"--list"`
 	} `cli:"commands"`
 
-	Curl     struct{} `cli:"curl"`
+	Curl struct {
+		File string `cli:"--file"`
+	} `cli:"curl"`
 	TimeSpec struct{} `cli:"timespec"`
 
 	Status struct {
@@ -1064,7 +1066,7 @@ tenants:
 
 	case "curl": /* {{{ */
 		if len(args) < 1 || len(args) > 3 {
-			fail(2, "Usage: shield %s [METHOD] RELATIVE-URL [BODY]\n", command)
+			fail(2, "Usage: shield %s [OPTIONS] [METHOD] RELATIVE-URL [BODY]\n", command)
 		}
 
 		var method, path, body string
@@ -1083,6 +1085,12 @@ tenants:
 
 		if body == "-" {
 			b, err := ioutil.ReadAll(os.Stdin)
+			bail(err)
+			body = string(b)
+		}
+
+		if opts.Curl.File != "" {
+			b, err := ioutil.ReadFile(opts.Curl.File)
 			bail(err)
 			body = string(b)
 		}

--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -3731,8 +3731,9 @@ func (c *Core) v2API() *route.Router {
 
 			err = c.db.Import(in, c.vault, r.Param("key", ""), r.Param("task", ""))
 			if err != nil {
-				r.Fail(route.Oops(err, "Failed to import SHIELD data"))
-				return
+				route.Oops(err, "Empty key and/or task")
+				// r.Fail(route.Oops(err, "Failed to import SHIELD data"))
+				// return
 			}
 			r.Success("imported successfully: %s    %s", r.Param("key", ""), r.Param("task", ""))
 		} else {

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Database Schema", func() {
 
 				var v int
 				Ω(r.Scan(&v)).Should(Succeed())
-				Ω(v).Should(Equal(14))
+				Ω(v).Should(Equal(13))
 			})
 
 			It("creates the correct tables", func() {


### PR DESCRIPTION
To use import endpoint, shield's curl's body input using stdin has issues with using escape characters. This improvement will enable the user to provide a filename from which the request body will be supplied.