### PR TITLE
[WIP] Fix the initialization flow for newer Vault versions

### DIFF
--- a/core/vault/client.go
+++ b/core/vault/client.go
@@ -125,6 +125,20 @@ func (c *Client) Initialize(crypt, master string) (string, error) {
 		return "", err
 	}
 
+	// Create the create mount "secret" as V2
+	var path = "secret"
+	var version = 2
+
+	err = c.vault.EnableSecretsMount(path, vaultkv.Mount{
+		Type:        "kv",
+		Description: fmt.Sprintf("A KV v%d Mount created by safe", version),
+		Options:     vaultkv.KVMountOptions{}.WithVersion(version),
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to create secret mount: %s", err)
+	}
+
 	k, p, err := GenerateFixedParameters()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Newer version of Vault do not create the secret mount by default causing a race condition on first creation.  This ensures the mount is created during setup.