### PR TITLE
Move nginx images to 1.31 on Debian trixie

### DIFF
--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.27-bookworm
+FROM nginx:1.31-trixie
 COPY htdocs /var/lib/data/demo/htdocs
 COPY init /init
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker/webdav/Dockerfile
+++ b/docker/webdav/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.27-bookworm
+FROM nginx:1.31-trixie
 MAINTAINER James Hunt <james@niftylogic.com>
 
 ADD nginx.conf /etc/nginx/


### PR DESCRIPTION
Supersedes the twenty open Snyk nginx PRs (#777, #784–#787, #789, #790, #793, #795, #798–#801, #803–#807, #809, #810).

## Why the Snyk PRs cannot simply be merged

Every one of those PRs targets `docker/demo/Dockerfile` only, and every one proposes a tag that is itself now stale:

| Tag | Docker Hub last rebuild |
|---|---|
| `nginx:1.27-bookworm` (current base) | 2025-06-11 |
| `nginx:1.29-bookworm` (newest Snyk proposal, #809/#810) | 2025-09-30 |
| `nginx:1.31-trixie` (this PR) | 2026-07-16 |

nginx publishes no `bookworm` variant past 1.29 — `1.30-bookworm` and `1.31-bookworm` do not exist. Staying current therefore requires moving to trixie, which no Snyk PR does. Merging any of them would leave the base a year behind and re-open the same alert on the next scan.

Snyk also never opened a PR against `docker/webdav/Dockerfile`, which runs the same stale nginx base and is published as `quay.io/shieldproject/webdav`. This PR updates both.

## Verification

Built both images from this branch and exercised them:

- **demo** — `GET /` returns 200 with the static root served from `/www`; `/init` copies `htdocs` as before.
- **webdav** — `PUT` 201, `GET` 200 with matching payload, `MKCOL` 201, `DELETE` 204, autoindex lists uploaded files.
- Both report `nginx/1.31.3`; neither logs any `emerg`, `crit`, or `error`.

Confirmed the new base retains what these images depend on: `--with-http_dav_module` is compiled in, the `nginx` user exists (uid 101) for `chown -R nginx /var/webdav`, and `bash` is present for `/init` and `/webdav`.

## Note on tag strategy

Pinning a floating *minor* (`1.31`) is what produced this backlog: `1.27` stopped receiving builds and Snyk opened a PR per nginx release for over a year. `nginx:mainline-trixie` or `nginx:stable-trixie` would track upstream without going stale. Left as-is here to keep the change to the version bump; worth deciding separately.