### PR TITLE
Add a storage health check button to the store view

### DIFF
--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -2610,32 +2610,28 @@ func (c *Core) v2API() *route.Router {
 
 		r.OK(store)
 	})
+	// }}}
 	r.Dispatch("POST /v2/tenants/:uuid/stores/:uuid/test", func(r *route.Request) { // {{{
-		// if c.IsNotTenantOperator(r, r.Args[1]) {
-		// 	return
-		// }
+		if c.IsNotTenantEngineer(r, r.Args[1]) {
+			return
+		}
 
 		store, err := c.db.GetStore(r.Args[2])
 		if err != nil {
 			r.Fail(route.Oops(err, "Unable to retrieve storage system information"))
 			return
 		}
-
 		if store == nil || store.TenantUUID != r.Args[1] {
-			r.Fail(route.NotFound(nil, "No such store"))
+			r.Fail(route.NotFound(err, "No such storage system"))
 			return
 		}
 
-		// if _, err = c.db.PauseJob(job.UUID); err != nil {
-		// 	r.Fail(route.Oops(err, "Unable to pause job"))
-		// 	return
-		// }
 		if _, err := c.db.CreateTestStoreTask("system", store); err != nil {
-			log.Errorf("failed to schedule storage test task (non-critical) for %s (%s): %s",
-						store.Name, store.UUID, err)
+			r.Fail(route.Oops(err, "Unable to schedule storage system test"))
+			return
 		}
 
-		r.Success("Testing store")
+		r.Success("Storage system test initiated")
 	})
 	// }}}
 	r.Dispatch("DELETE /v2/tenants/:uuid/stores/:uuid", func(r *route.Request) { // {{{

--- a/core/api_v2.go
+++ b/core/api_v2.go
@@ -3545,6 +3545,29 @@ func (c *Core) v2API() *route.Router {
 		r.OK(store)
 	})
 	// }}}
+	r.Dispatch("POST /v2/global/stores/:uuid/test", func(r *route.Request) { // {{{
+		if c.IsNotSystemEngineer(r) {
+			return
+		}
+
+		store, err := c.db.GetStore(r.Args[1])
+		if err != nil {
+			r.Fail(route.Oops(err, "Unable to retrieve storage system information"))
+			return
+		}
+		if store == nil || store.TenantUUID != db.GlobalTenantUUID {
+			r.Fail(route.NotFound(err, "No such storage system"))
+			return
+		}
+
+		if _, err := c.db.CreateTestStoreTask("system", store); err != nil {
+			r.Fail(route.Oops(err, "Unable to schedule storage system test"))
+			return
+		}
+
+		r.Success("Storage system test initiated")
+	})
+	// }}}
 	r.Dispatch("DELETE /v2/global/stores/:uuid", func(r *route.Request) { // {{{
 		if c.IsNotSystemEngineer(r) {
 			return

--- a/t/urls
+++ b/t/urls
@@ -19,6 +19,7 @@ system engineer #!/admin/stores/store
 system engineer #!/admin/stores/new
 system engineer #!/admin/stores/edit
 system engineer #!/admin/stores/delete
+system engineer #!/admin/stores/test
 
 system engineer #!/admin/policies
 system engineer #!/admin/policies/store
@@ -39,6 +40,7 @@ tenant operator #!/stores/store
 tenant engineer #!/stores/new
 tenant engineer #!/stores/edit
 tenant engineer #!/stores/delete
+tenant engineer #!/stores/test
 
 tenant operator #!/policies
 tenant operator #!/policies/store

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -2524,6 +2524,7 @@ for job <em>[[= _.task.job_uuid ]]</em>
                   || (!_.admin && AEGIS.is(store.tenant_uuid, 'engineer'))) { ]]
               <a class="edit"   href="#!/[[= _.admin ? 'admin/' : '' ]]stores/edit:uuid:[[= store.uuid ]]">Edit</a>
               <a class="delete" href="#!/[[= _.admin ? 'admin/' : '' ]]stores/delete:uuid:[[= store.uuid ]]">Delete</a>
+              <a class="edit" href="#!/[[= _.admin ? 'admin/' : '' ]]stores/test:uuid:[[= store.uuid ]]">Test</a>
               [[ } ]]
             [[ } ]]
 
@@ -2780,7 +2781,27 @@ for job <em>[[= _.task.job_uuid ]]</em>
               <button class="danger" rel="yes">Yes, Delete It</button>
             </div>
           </div>
-    <!-- }}} --></script>
+    <!-- }}} --></script><script type="text/html" id="template:stores-test"><!-- {{{ -->
+      [[#
+      {stores-test}
+
+      A modal interaction screen that requires the operator to acknowledge
+      that what they are about to do is in fact to test a storage system, that it
+      might be dangerous, and it might not work out.
+    ]]
+        <div class="confirm">
+          <h2>Test The <em>[[= h(_.store.name) ]]</em> Cloud Storage System?</h2>
+          <p>You have requested that SHIELD perform a health check for
+            the cloud storage system "[[= h(_.store.name) ]]"</p>
+
+          <p class="q">Are you sure you want to test <em>[[= h(_.store.name) ]]</em>?</p>
+
+          <div class="a">
+            <button class="closes danger" rel="close">No, Cancel This Operation</button>
+            <button class="closes safe" rel="yes">Yes, Initiate Test</button>
+          </div>
+        </div>
+  <!-- }}} --></script>
 
     <script type="text/html" id="template:tenants"><!-- {{{ -->
       [[#

--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -2781,27 +2781,28 @@ for job <em>[[= _.task.job_uuid ]]</em>
               <button class="danger" rel="yes">Yes, Delete It</button>
             </div>
           </div>
-    <!-- }}} --></script><script type="text/html" id="template:stores-test"><!-- {{{ -->
+    <!-- }}} --></script>
+    <script type="text/html" id="template:stores-test"><!-- {{{ -->
       [[#
       {stores-test}
 
       A modal interaction screen that requires the operator to acknowledge
-      that what they are about to do is in fact to test a storage system, that it
-      might be dangerous, and it might not work out.
+      that what they are about to do is in fact to test a storage system,
+      by writing and then removing a small canary blob.
     ]]
-        <div class="confirm">
-          <h2>Test The <em>[[= h(_.store.name) ]]</em> Cloud Storage System?</h2>
-          <p>You have requested that SHIELD perform a health check for
-            the cloud storage system "[[= h(_.store.name) ]]"</p>
+          <div class="confirm">
+            <h2>Test The <em>[[= h(_.store.name) ]]</em> Cloud Storage System?</h2>
+            <p>You have requested that SHIELD perform a health check for
+            the cloud storage system "[[= h(_.store.name) ]]".</p>
 
-          <p class="q">Are you sure you want to test <em>[[= h(_.store.name) ]]</em>?</p>
+            <p class="q">Are you sure you want to test <em>[[= h(_.store.name) ]]</em>?</p>
 
-          <div class="a">
-            <button class="closes danger" rel="close">No, Cancel This Operation</button>
-            <button class="closes safe" rel="yes">Yes, Initiate Test</button>
+            <div class="a">
+              <button class="closes safe" rel="close">No, Cancel This Operation</button>
+              <button class="closes danger" rel="yes">Yes, Initiate Test</button>
+            </div>
           </div>
-        </div>
-  <!-- }}} --></script>
+    <!-- }}} --></script>
 
     <script type="text/html" id="template:tenants"><!-- {{{ -->
       [[#

--- a/web/htdocs/js/shield.js
+++ b/web/htdocs/js/shield.js
@@ -1301,6 +1301,43 @@ function dispatch(page) {
     break; /* #!/admin/stores/delete */
     // }}}
 
+  case '#!/admin/stores/test': /* {{{ */
+    if (!AEGIS.is('engineer')) {
+      $('#main').template('access-denied', { level: 'system', need: 'engineer' });
+      break;
+    }
+    api({
+      type: 'GET',
+      url:  '/v2/global/stores/'+args.uuid,
+      error: "Failed to retrieve storage system information from the SHIELD API.",
+      success: function (store) {
+        modal($($.template('stores-test', { store: store }))
+          .on('click', '[rel="yes"]', function (event) {
+            event.preventDefault();
+            api({
+              type: 'POST',
+              url:  '/v2/global/stores/'+args.uuid+'/test',
+              error: "Unable to test the storage system",
+              complete: function () {
+                modal(true);
+              },
+              success: function (event) {
+                goto('#!/admin/stores/store:uuid:'+args.uuid);
+                banner('Started storage health check.');
+              }
+            });
+          })
+          .on('click', '[rel="close"]', function (event) {
+            modal(true);
+            goto('#!/admin/stores/store:uuid:'+args.uuid);
+          })
+        );
+      }
+    });
+
+    break; /* #!/admin/stores/test */
+    // }}}
+
   case '#!/admin/sessions': /* {{{ */
     if (!AEGIS.is('admin')) {
       $('#main').template('access-denied', { level: 'system', need: 'admin' });

--- a/web/htdocs/js/shield.js
+++ b/web/htdocs/js/shield.js
@@ -496,38 +496,41 @@ function dispatch(page) {
       $('#main').template('you-have-no-tenants');
       break;
     }
+    if (!AEGIS.is('tenant', 'engineer')) {
+      $('#main').template('access-denied', { level: 'tenant', need: 'engineer' });
+      break;
+    }
     api({
-        type: 'GET',
-        url:  '/v2/tenants/'+AEGIS.current.uuid+'/stores/'+args.uuid,
-        error: "Failed to retrieve storage system information from the SHIELD API.",
-        success: function (store) {
-          modal($($.template('stores-test', { store: store }))
-            .on('click', '[rel="yes"]', function (event) {
-              event.preventDefault();
-              api({
-                type: 'POST',
-                url:  '/v2/tenants/'+AEGIS.current.uuid+'/stores/'+args.uuid+'/test',
-                complete: function () {
+      type: 'GET',
+      url:  '/v2/tenants/'+AEGIS.current.uuid+'/stores/'+args.uuid,
+      error: "Failed to retrieve storage system information from the SHIELD API.",
+      success: function (store) {
+        modal($($.template('stores-test', { store: store }))
+          .on('click', '[rel="yes"]', function (event) {
+            event.preventDefault();
+            api({
+              type: 'POST',
+              url:  '/v2/tenants/'+AEGIS.current.uuid+'/stores/'+args.uuid+'/test',
+              error: "Unable to test the storage system",
+              complete: function () {
                 modal(true);
-                },
-                success: function (event) {
-                  goto('#!/stores/store:uuid:');
-                  banner('Started storage health check.');
-                },
-                error: function (event) {
-                  banner('Unable to test the storage system');
-                }
-              });
-            })
-            .on('click', '[rel="close"]', function (event) {
+              },
+              success: function (event) {
+                goto('#!/stores/store:uuid:'+args.uuid);
+                banner('Started storage health check.');
+              }
+            });
+          })
+          .on('click', '[rel="close"]', function (event) {
             modal(true);
             goto('#!/stores/store:uuid:'+args.uuid);
-            })
-          );
-        }
+          })
+        );
+      }
     });
+
     break; /* #!/stores/test */
-    // // }}}  
+    // }}}
   case '#!/stores/delete': /* {{{ */
     if (!AEGIS.current) {
       $('#main').template('you-have-no-tenants');

--- a/web/htdocs/js/shield.js
+++ b/web/htdocs/js/shield.js
@@ -491,6 +491,43 @@ function dispatch(page) {
 
     break; /* #!/stores/edit */
     // }}}
+  case '#!/stores/test': /* {{{ */
+    if (!AEGIS.current) {
+      $('#main').template('you-have-no-tenants');
+      break;
+    }
+    api({
+        type: 'GET',
+        url:  '/v2/tenants/'+AEGIS.current.uuid+'/stores/'+args.uuid,
+        error: "Failed to retrieve storage system information from the SHIELD API.",
+        success: function (store) {
+          modal($($.template('stores-test', { store: store }))
+            .on('click', '[rel="yes"]', function (event) {
+              event.preventDefault();
+              api({
+                type: 'POST',
+                url:  '/v2/tenants/'+AEGIS.current.uuid+'/stores/'+args.uuid+'/test',
+                complete: function () {
+                modal(true);
+                },
+                success: function (event) {
+                  goto('#!/stores/store:uuid:');
+                  banner('Started storage health check.');
+                },
+                error: function (event) {
+                  banner('Unable to test the storage system');
+                }
+              });
+            })
+            .on('click', '[rel="close"]', function (event) {
+            modal(true);
+            goto('#!/stores/store:uuid:'+args.uuid);
+            })
+          );
+        }
+    });
+    break; /* #!/stores/test */
+    // // }}}  
   case '#!/stores/delete': /* {{{ */
     if (!AEGIS.current) {
       $('#main').template('you-have-no-tenants');


### PR DESCRIPTION
Adds a `Test` button to the store view that triggers a storage health
check task, so operators can re-check a failing cloud store after
fixing the underlying problem.

Supersedes #748. The original commit by @pururval is preserved as-is;
the follow-up commits address review findings rather than rewriting
their work.

### Follow-up fixes on top of the original commit

- **Authorization.** The tenant route shipped with its access check
  commented out, so any authenticated session could queue a health
  check against another tenant's store. Enabled, requiring the tenant
  engineer role like the sibling store routes.

- **Error handling.** A failed `CreateTestStoreTask` was logged as
  non-critical and still returned success. That pattern is correct on
  store create, where the test is incidental, but here scheduling is
  the whole point, so the request now fails.

- **Global stores.** The store view offers the button to system
  engineers too, but only a tenant-scoped route existed. Added
  `POST /v2/global/stores/:uuid/test`.

- **Admin dispatch.** The view built an `#!/admin/stores/test` link
  with no matching `dispatch()` case, so the button did nothing in the
  admin context.

- **Redirect.** The success handler navigated to
  `#!/stores/store:uuid:` with the uuid omitted, landing on a broken
  store view.

- **Modal markup.** The `safe` and `danger` button classes were
  inverted relative to every other confirm modal, colouring Cancel as
  the destructive choice. Also reworded the copy: the test writes a
  random blob, retrieves it, and purges it, so the "might be
  dangerous" warning was misleading.

### Verification

`gofmt`, `go build ./...`, and `go vet` are clean; `go test
./db/... ./core/...` passes. `node --check` passes on `shield.js`.
This repository has no CI, so that is local verification only.

Closes #744
